### PR TITLE
Configure single sign out filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The supported properties are:
 | `security.cas.server.protocol-version`      | `3`                            | Determine which CAS protocol version to be used, only protocol version 1, 2 or 3 is supported.                                                                                                                                                                     |
 | `security.cas.server.base-url`              |                                | The start of the CAS server url, i.e. https://localhost:8443/cas                                                                                                                                                                                                   |
 | `security.cas.server.paths.login`           | `/login`                       | Defines the location of the CAS server login path that will be append to the existing `security.cas.server.base-url` url                                                                                                                                           |
-| `security.cas.server.paths.logout`           | `/logout`                      | Defines the location of the CAS server logout path that will be append to the existing `security.cas.server.base-url` url                                                                                                                                          |
+| `security.cas.server.paths.logout`          | `/logout`                      | Defines the location of the CAS server logout path that will be append to the existing `security.cas.server.base-url` url                                                                                                                                          |
 | `security.cas.service.resolution-mode`      | `static`                       | Resolution modes can be `static` or `dynamic`, by default is `static` and you must fill `security.cas.service.base-url` whereas in `dynamic` mode service url will be generated from receiving `HttpServletRequest`                                                |
 | `security.cas.service.base-url`             |                                | The name of the server this application is hosted on. Service URL will be dynamically constructed using this, i.e. https://localhost:8443 (you must include the protocol, but port is optional if it's a standard port).  Skipped if resolution mode is `dynamic`. |
 | `security.cas.service.paths.login`          | `/login`                       | Defines the application login path that will be append to the existing `security.cas.service.base-url` url                                                                                                                                                         |
@@ -111,6 +111,12 @@ public class CustomCasSecurityConfiguration extends CasSecurityConfigurerAdapter
     public void configure(CasAuthenticationFilterConfigurer filter) {
         // Here you can configure CasAuthenticationFilter
     }
+    
+    @Override
+    public void configure(CasSingleSignOutFilterConfigurer filter) {
+        // Here you can configure SingleSignOutFilter
+    }
+
 
     @Override
     public void configure(CasAuthenticationProviderSecurityBuilder provider) {

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
@@ -8,4 +8,6 @@ public interface CasSecurityConfigurer {
     void configure(CasAuthenticationFilterConfigurer filter);
 
     void configure(CasAuthenticationProviderSecurityBuilder provider);
+
+    void configure(CasSingleSignOutFilterConfigurer filter);
 }

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
@@ -10,6 +10,10 @@ public abstract class CasSecurityConfigurerAdapter implements CasSecurityConfigu
     }
 
     @Override
+    public void configure(CasSingleSignOutFilterConfigurer filter) {
+    }
+
+    @Override
     public void configure(CasAuthenticationProviderSecurityBuilder provider) {
     }
 

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSingleSignOutFilterConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSingleSignOutFilterConfigurer.java
@@ -1,0 +1,53 @@
+package com.kakawait.spring.boot.security.cas;
+
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.jasig.cas.client.session.SessionMappingStorage;
+import org.jasig.cas.client.session.SingleSignOutFilter;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Thibaud Leprêtre
+ */
+@Setter
+@Accessors(fluent = true)
+public class CasSingleSignOutFilterConfigurer {
+
+    @NonNull
+    private SessionMappingStorage sessionMappingStorage;
+
+    @NonNull
+    private String relayStateParameterName;
+
+    @NonNull
+    private String frontLogoutParameterName;
+
+    @NonNull
+    private String logoutParameterName;
+
+    @NonNull
+    private String artifactParameterName;
+
+    void configure(SingleSignOutFilter filter) {
+        if (sessionMappingStorage != null) {
+            filter.setSessionMappingStorage(sessionMappingStorage);
+        }
+
+        if (StringUtils.hasText(relayStateParameterName)) {
+            filter.setRelayStateParameterName(relayStateParameterName);
+        }
+
+        if (StringUtils.hasText(frontLogoutParameterName)) {
+            filter.setFrontLogoutParameterName(frontLogoutParameterName);
+        }
+
+        if (StringUtils.hasText(logoutParameterName)) {
+            filter.setLogoutParameterName(logoutParameterName);
+        }
+
+        if (StringUtils.hasText(artifactParameterName)) {
+            filter.setArtifactParameterName(artifactParameterName);
+        }
+    }
+}


### PR DESCRIPTION
Missing single sign out filter to handle single sign out request when logout from CAS server or other services.

Filter has been placed just before `CsrfFilter` to avoid any exception with that filter since single sign out request is a `POST` request!

fixes #2