### PR TITLE
Allow disable proxy callback

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
@@ -74,13 +74,7 @@ public class CasSecurityAutoConfiguration {
         ServiceProperties serviceProperties = new ServiceProperties();
 
         URI baseUrl = casSecurityProperties.getService().getBaseUrl();
-        if (baseUrl != null) {
-            String clientLoginUrl = UriComponentsBuilder
-                    .fromUri(baseUrl)
-                    .path(casSecurityProperties.getService().getPaths().getLogin())
-                    .toUriString();
-            serviceProperties.setService(clientLoginUrl);
-        }
+        serviceProperties.setService(buildUrl(baseUrl, casSecurityProperties.getService().getPaths().getLogin()));
         return serviceProperties;
     }
 
@@ -308,6 +302,16 @@ public class CasSecurityAutoConfiguration {
 
         @ConditionalOnProperty(value = "security.cas.server.base-url")
         static class ServerInstanceProperty {}
+    }
+
+    static String buildUrl(URI baseUrl, String path) {
+        if (baseUrl != null) {
+            return UriComponentsBuilder
+                    .fromUri(baseUrl)
+                    .path(path)
+                    .toUriString();
+        }
+        return path;
     }
 
 }

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityProperties.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityProperties.java
@@ -93,6 +93,13 @@ public class CasSecurityProperties {
         private ServiceResolutionMode resolutionMode = ServiceResolutionMode.STATIC;
 
         /**
+         * Determine if proxy callback url should be set inside
+         * {@link org.jasig.cas.client.validation.Cas20ServiceTicketValidator#setProxyCallbackUrl(String)} and thus
+         * activating pgt callback.
+         */
+        private boolean ProxyCallbackEnabled = true;
+
+        /**
          * CAS Service base url (your application base url)
          */
         private URI baseUrl;
@@ -128,4 +135,5 @@ public class CasSecurityProperties {
         STATIC,
         DYNAMIC
     }
+
 }

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasTicketValidatorConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasTicketValidatorConfiguration.java
@@ -7,12 +7,11 @@ import org.jasig.cas.client.validation.Cas30ProxyTicketValidator;
 import org.jasig.cas.client.validation.TicketValidator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.cas.ServiceProperties;
 
 import java.net.URI;
+
+import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration.buildUrl;
 
 /**
  * @author Thibaud Leprêtre
@@ -31,7 +30,11 @@ public class CasTicketValidatorConfiguration {
     TicketValidator cas30ProxyTicketValidator() {
         Cas20ServiceTicketValidator ticketValidator = new Cas30ProxyTicketValidator(
                 casSecurityProperties.getServer().getBaseUrl().toASCIIString());
-        ticketValidator.setProxyCallbackUrl(casSecurityProperties.getService().getPaths().getProxyCallback());
+        URI baseUrl = casSecurityProperties.getService().getBaseUrl();
+        if (casSecurityProperties.getService().isProxyCallbackEnabled()) {
+            ticketValidator.setProxyCallbackUrl(
+                    buildUrl(baseUrl, casSecurityProperties.getService().getPaths().getProxyCallback()));
+        }
         return ticketValidator;
     }
 
@@ -40,7 +43,11 @@ public class CasTicketValidatorConfiguration {
     TicketValidator cas20ProxyTicketValidator() {
         Cas20ServiceTicketValidator ticketValidator = new Cas20ProxyTicketValidator(
                 casSecurityProperties.getServer().getBaseUrl().toASCIIString());
-        ticketValidator.setProxyCallbackUrl(casSecurityProperties.getService().getPaths().getProxyCallback());
+        URI baseUrl = casSecurityProperties.getService().getBaseUrl();
+        if (casSecurityProperties.getService().isProxyCallbackEnabled()) {
+            ticketValidator.setProxyCallbackUrl(
+                    buildUrl(baseUrl, casSecurityProperties.getService().getPaths().getProxyCallback()));
+        }
         return ticketValidator;
     }
 


### PR DESCRIPTION
New property `security.cas.service.proxy-callback-enabled` that will allow you to disable proxy callback, by default value is `true` (so proxy callback is enabled)

fixes #3