### PR TITLE
Default logout implementation

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
@@ -1,9 +1,13 @@
 package com.kakawait.spring.boot.security.cas;
 
+import org.springframework.security.config.annotation.SecurityConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+
 /**
  * @author Thibaud Leprêtre
  */
-public interface CasSecurityConfigurer {
+public interface CasSecurityConfigurer extends SecurityConfigurer<DefaultSecurityFilterChain, HttpSecurity> {
 
     void configure(CasAuthenticationFilterConfigurer filter);
 

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
@@ -1,9 +1,14 @@
 package com.kakawait.spring.boot.security.cas;
 
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+
 /**
  * @author Thibaud Leprêtre
  */
-public abstract class CasSecurityConfigurerAdapter implements CasSecurityConfigurer {
+public abstract class CasSecurityConfigurerAdapter
+        extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> implements CasSecurityConfigurer {
 
     @Override
     public void configure(CasAuthenticationFilterConfigurer filter) {

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityProperties.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityProperties.java
@@ -72,7 +72,7 @@ public class CasSecurityProperties {
         private Paths paths = new Paths();
 
         @Data
-        static class Paths {
+        public static class Paths {
             /**
              * CAS Server login path that will be append to {@link Server#baseUrl}
              *

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>cas-security-spring-boot-starter</artifactId>
             <version>${project.version}</version>

--- a/cas-security-spring-boot-sample/src/main/resources/templates/logout.html
+++ b/cas-security-spring-boot-sample/src/main/resources/templates/logout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Logout page</title>
+</head>
+<body>
+    <h2>Do you want to log out of CAS?</h2>
+    <p>You have logged out of this application, but may still have an active single-sign on session with CAS.</p>
+    <p><a href="/cas/logout" th:href="@{/cas/logout}">Logout of CAS</a></p>
+</body>
+</html>


### PR DESCRIPTION
Original problem was about `/logout` path that returning `404`, this was a wanted behavior since spring security disable `GET` logout if CSRF is enabled.

Thus I enhance current configuer adapter to be able to edit `HttpSecurity` object, like for example enable `GET` logout even if CSRF is enabled.

In addition, a default behavior has been added to `/logout` path that logout application **and from CAS server**

fixes #10