### PR TITLE
Apply filter on any requests with ticket param

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationFilterConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationFilterConfigurer.java
@@ -1,12 +1,13 @@
 package com.kakawait.spring.boot.security.cas;
 
-import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetailsSource;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * @author Thibaud Leprêtre
@@ -15,26 +16,32 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 @Accessors(fluent = true)
 public class CasAuthenticationFilterConfigurer {
 
-    @NonNull
+    private RequestMatcher requiresAuthenticationRequestMatcher;
+
     private AuthenticationFailureHandler authenticationFailureHandler;
 
-    @NonNull
     private AuthenticationFailureHandler proxyAuthenticationFailureHandler;
 
-    @NonNull
+    private AuthenticationSuccessHandler authenticationSuccessHandler;
+
     private ProxyGrantingTicketStorage proxyGrantingTicketStorage;
 
-    @NonNull
     private ServiceAuthenticationDetailsSource serviceAuthenticationDetailsSource;
 
     private String proxyReceptorUrl;
 
     void configure(CasAuthenticationFilter filter) {
+        if (requiresAuthenticationRequestMatcher != null) {
+            filter.setRequiresAuthenticationRequestMatcher(requiresAuthenticationRequestMatcher);
+        }
         if (authenticationFailureHandler != null) {
             filter.setAuthenticationFailureHandler(authenticationFailureHandler);
         }
         if (proxyAuthenticationFailureHandler != null) {
             filter.setProxyAuthenticationFailureHandler(proxyAuthenticationFailureHandler);
+        }
+        if (authenticationFailureHandler != null) {
+            filter.setAuthenticationSuccessHandler(authenticationSuccessHandler);
         }
         if (proxyReceptorUrl != null) {
             filter.setProxyReceptorUrl(proxyReceptorUrl);

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationSuccessHandler.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationSuccessHandler.java
@@ -1,0 +1,34 @@
+package com.kakawait.spring.boot.security.cas;
+
+import lombok.NonNull;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Thibaud Leprêtre
+ */
+class CasAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final String ticketParameterName;
+
+    CasAuthenticationSuccessHandler(@NonNull String ticketParameterName) {
+        this.ticketParameterName = ticketParameterName;
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
+        String url = super.determineTargetUrl(request, response);
+        String ticket = request.getParameter(ticketParameterName);
+        if (ticket != null) {
+            url = UriComponentsBuilder
+                    .fromUriString(request.getRequestURL().toString())
+                    .replaceQueryParam(ticketParameterName, new Object[0])
+                    .build()
+                    .toUriString();
+        }
+        return url;
+    }
+}

--- a/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java
+++ b/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java
@@ -13,6 +13,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -87,19 +90,31 @@ public class CasSecuritySpringBootSampleApplication {
         }
     }
 
+    @Controller
+    @RequestMapping(value = "/")
+    static class IndexController {
+
+        @RequestMapping
+        public String hello(Principal principal, Model model) {
+            if (StringUtils.hasText(principal.getName())) {
+                model.addAttribute("username", principal.getName());
+            }
+            return "index";
+        }
+
+        @RequestMapping(path = "/ignored")
+        public String ignored() {
+            return "index";
+        }
+    }
 
     @RestController
-    @RequestMapping(value = "/")
+    @RequestMapping(value = "/api")
     static class HelloWorldController {
 
         @GetMapping
         public @ResponseBody String hello(Principal principal) {
             return principal == null ? "Hello anonymous" : "Hello " + principal.getName();
-        }
-
-        @GetMapping(path = "/ignored")
-        public @ResponseBody String ignored() {
-            return "Hello world!";
         }
     }
 

--- a/cas-security-spring-boot-sample/src/main/resources/application.yml
+++ b/cas-security-spring-boot-sample/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 security:
   basic:
     enabled: true
-  ignored: /ignored
+  ignored: /ignored, /**/favicon.ico
   cas:
     server:
       base-url: http://localhost:8080/cas/

--- a/cas-security-spring-boot-sample/src/main/resources/templates/index.html
+++ b/cas-security-spring-boot-sample/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Index page</title>
+</head>
+<body>
+<h2 th:text="${username} ? 'Hello, ' + ${username} + '!' : 'Hello world!'">Hello world!</h2>
+</body>
+</html>


### PR DESCRIPTION
Until now `CasAuthenticationFilter` was only apply on `/login` page that mean even if you call an path with `?ticket=ST-XXX` it was unread and considered as no auth.

We are now applying _filter_ on `/login` and any path with `ticket` parameter presents

fixes #14