### PR TITLE
Revamp configuration to improve reusability

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasHttpSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasHttpSecurityConfigurer.java
@@ -1,0 +1,244 @@
+package com.kakawait.spring.boot.security.cas;
+
+import lombok.NonNull;
+import org.jasig.cas.client.session.SingleSignOutFilter;
+import org.springframework.boot.autoconfigure.security.SecurityAuthorizeMode;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.autoconfigure.security.SpringBootWebSecurityConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.CasAuthenticationProvider;
+import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
+import org.springframework.security.cas.web.CasAuthenticationFilter;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @author Thibaud Leprêtre
+ */
+public class CasHttpSecurityConfigurer extends AbstractHttpConfigurer<CasHttpSecurityConfigurer, HttpSecurity> {
+
+    private final AuthenticationManager authenticationManager;
+
+    private CasHttpSecurityConfigurerAdapter securityConfigurerAdapter;
+
+    private boolean isInitialized = false;
+
+    private CasHttpSecurityConfigurer() {
+        this(null);
+    }
+
+    private CasHttpSecurityConfigurer(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    public static AbstractHttpConfigurer<CasHttpSecurityConfigurer, HttpSecurity> cas() {
+        return new CasHttpSecurityConfigurer();
+    }
+
+    public static AbstractHttpConfigurer<CasHttpSecurityConfigurer, HttpSecurity> cas(
+            AuthenticationManager authenticationManager) {
+        return new CasHttpSecurityConfigurer(authenticationManager);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated use {@link #configure(HttpSecurity)} instead.
+     * Will not be removed but until this issue was not treat
+     * https://github.com/spring-projects/spring-security/issues/4422 I still prefer using this
+     * {@link SecurityConfigurerAdapter} directly like following
+     *
+     * <pre>{@code
+     * CasHttpSecurityConfigurer.cas().configure(http);
+     * }</pre>
+     *
+     * instead of
+     *
+     * <pre>{@code
+     * http.apply(CasHttpSecurityConfigurer.cas());
+     * }</pre>
+     */
+    @Override
+    @Deprecated
+    public void init(HttpSecurity http) throws Exception {
+        if (!isInitialized) {
+            ApplicationContext context = http.getSharedObject(ApplicationContext.class);
+            CasHttpSecurityConfigurerAdapter securityConfigurerAdapter = getCasHttpSecurityConfigurerAdapter(context);
+            securityConfigurerAdapter.init(http);
+            isInitialized = true;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * In addition {@link #configure(HttpSecurity)} will call {@link #init(HttpSecurity)} in order to be used without
+     * {@link HttpSecurity#apply(SecurityConfigurerAdapter)} usage, related to
+     * https://github.com/spring-projects/spring-security/issues/4422 issue.
+     *
+     * Thus when using
+     *
+     * <pre>{@code
+     * CasHttpSecurityConfigurer.cas().configure(http);
+     * }</pre>
+     *
+     * {@code configure(http)} will also call {@link CasHttpSecurityConfigurerAdapter#init(HttpSecurity)} and no need
+     * to write following duplicates
+     *
+     * <pre>{@code
+     * CasHttpSecurityConfigurer.cas().init(http);
+     * CasHttpSecurityConfigurer.cas().configure(http);
+     * }</pre>
+     */
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        init(http);
+        ApplicationContext context = http.getSharedObject(ApplicationContext.class);
+        CasHttpSecurityConfigurerAdapter securityConfigurerAdapter = getCasHttpSecurityConfigurerAdapter(context);
+        securityConfigurerAdapter.configure(http);
+    }
+
+    private CasHttpSecurityConfigurerAdapter getCasHttpSecurityConfigurerAdapter(ApplicationContext context) {
+        if (securityConfigurerAdapter == null) {
+            securityConfigurerAdapter = context
+                    .getAutowireCapableBeanFactory()
+                    .createBean(CasHttpSecurityConfigurerAdapter.class);
+        }
+        if (authenticationManager != null) {
+            securityConfigurerAdapter.setAuthenticationManager(authenticationManager);
+        }
+        return securityConfigurerAdapter;
+    }
+
+    static class CasHttpSecurityConfigurerAdapter
+            extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+        private final CasAuthenticationFilterConfigurer filterConfigurer = new CasAuthenticationFilterConfigurer();
+
+        private final CasSingleSignOutFilterConfigurer singleSignOutFilterConfigurer =
+                new CasSingleSignOutFilterConfigurer();
+
+        private final CasAuthenticationProviderSecurityBuilder providerBuilder =
+                new CasAuthenticationProviderSecurityBuilder();
+
+        private final List<CasSecurityConfigurer> configurers;
+
+        private final SecurityProperties securityProperties;
+
+        private final CasSecurityProperties casSecurityProperties;
+
+        private final CasAuthenticationEntryPoint authenticationEntryPoint;
+
+        private final ServiceProperties serviceProperties;
+
+        private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+        private AuthenticationManager authenticationManager;
+
+        private boolean authenticationManagerInitialized;
+
+        public CasHttpSecurityConfigurerAdapter(List<CasSecurityConfigurer> configurers,
+                SecurityProperties securityProperties, CasSecurityProperties casSecurityProperties,
+                CasAuthenticationEntryPoint authenticationEntryPoint, ServiceProperties serviceProperties,
+                ObjectPostProcessor<Object> objectPostProcessor) {
+            this.configurers = configurers;
+            this.securityProperties = securityProperties;
+            this.casSecurityProperties = casSecurityProperties;
+            this.authenticationEntryPoint = authenticationEntryPoint;
+            this.serviceProperties = serviceProperties;
+            authenticationManagerBuilder = new AuthenticationManagerBuilder(objectPostProcessor);
+        }
+
+        @PostConstruct
+        private void init() {
+            configurers.forEach(c -> {
+                c.configure(filterConfigurer);
+                c.configure(singleSignOutFilterConfigurer);
+                c.configure(providerBuilder);
+            });
+        }
+
+        @Override
+        public void init(HttpSecurity http) throws Exception {
+            CasAuthenticationFilter filter = new CasAuthenticationFilter();
+            filter.setAuthenticationManager(authenticationManager());
+            filter.setRequiresAuthenticationRequestMatcher(getRequestMatcher(serviceProperties));
+            filter.setAuthenticationSuccessHandler(getAuthenticationSuccessHandler(serviceProperties));
+            filterConfigurer.configure(filter);
+
+            SingleSignOutFilter singleSignOutFilter = new SingleSignOutFilter();
+            singleSignOutFilterConfigurer.configure(singleSignOutFilter);
+
+            if (securityProperties.isRequireSsl()) {
+                http.requiresChannel().anyRequest().requiresSecure();
+            }
+            if (!securityProperties.isEnableCsrf()) {
+                http.csrf().disable();
+            }
+            SpringBootWebSecurityConfiguration.configureHeaders(http.headers(), securityProperties.getHeaders());
+
+            http.exceptionHandling().authenticationEntryPoint(authenticationEntryPoint)
+                .and()
+                .addFilterBefore(singleSignOutFilter, CsrfFilter.class)
+                .addFilter(filter);
+            if (securityProperties.getBasic().isEnabled()) {
+                AuthenticationManager authenticationManager = http
+                        .getSharedObject(ApplicationContext.class)
+                        .getBean(AuthenticationManager.class);
+                BasicAuthenticationFilter basicAuthFilter = new BasicAuthenticationFilter(authenticationManager);
+                http.addFilterBefore(basicAuthFilter, CasAuthenticationFilter.class);
+            }
+            SecurityAuthorizeMode mode = casSecurityProperties.getAuthorizeMode();
+            if (mode == SecurityAuthorizeMode.ROLE) {
+                List<String> roles = securityProperties.getUser().getRole();
+                http.authorizeRequests().anyRequest().hasAnyRole(roles.toArray(new String[roles.size()]));
+            } else if (mode == SecurityAuthorizeMode.AUTHENTICATED) {
+                http.authorizeRequests().anyRequest().authenticated();
+            }
+        }
+
+        void configure(AuthenticationManagerBuilder auth) throws Exception {
+            CasAuthenticationProvider provider = providerBuilder.build();
+            provider.setServiceProperties(serviceProperties);
+            auth.authenticationProvider(provider);
+        }
+
+        AuthenticationManager authenticationManager() throws Exception {
+            if (!authenticationManagerInitialized) {
+                configure(authenticationManagerBuilder);
+                authenticationManager = authenticationManagerBuilder.build();
+                authenticationManagerInitialized = true;
+            }
+            return authenticationManager;
+        }
+
+        void setAuthenticationManager(@NonNull AuthenticationManager authenticationManager) {
+            authenticationManagerInitialized = true;
+            this.authenticationManager = authenticationManager;
+        }
+
+        private AuthenticationSuccessHandler getAuthenticationSuccessHandler(ServiceProperties serviceProperties) {
+            return new CasAuthenticationSuccessHandler(serviceProperties.getArtifactParameter());
+        }
+
+        private RequestMatcher getRequestMatcher(ServiceProperties serviceProperties) {
+            return new OrRequestMatcher(
+                    new AntPathRequestMatcher(casSecurityProperties.getService().getPaths().getLogin()),
+                    request -> request.getParameter(serviceProperties.getArtifactParameter()) != null);
+        }
+    }
+}

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurer.java
@@ -1,17 +1,26 @@
 package com.kakawait.spring.boot.security.cas;
 
+import org.springframework.security.config.annotation.SecurityBuilder;
 import org.springframework.security.config.annotation.SecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.DefaultSecurityFilterChain;
 
 /**
  * @author Thibaud Leprêtre
  */
-public interface CasSecurityConfigurer extends SecurityConfigurer<DefaultSecurityFilterChain, HttpSecurity> {
+public interface CasSecurityConfigurer {
 
     void configure(CasAuthenticationFilterConfigurer filter);
 
     void configure(CasAuthenticationProviderSecurityBuilder provider);
 
     void configure(CasSingleSignOutFilterConfigurer filter);
+
+    void configure(HttpSecurity http) throws Exception;
+
+    /**
+     * @deprecated Use {@link SecurityConfigurer#configure(SecurityBuilder)} instead.
+     * Will be removed on release 1.0.0!
+     */
+    @Deprecated
+    void init(HttpSecurity http) throws Exception;
 }

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java
@@ -1,14 +1,11 @@
 package com.kakawait.spring.boot.security.cas;
 
-import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.DefaultSecurityFilterChain;
 
 /**
  * @author Thibaud Leprêtre
  */
-public abstract class CasSecurityConfigurerAdapter
-        extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> implements CasSecurityConfigurer {
+public abstract class CasSecurityConfigurerAdapter implements CasSecurityConfigurer {
 
     @Override
     public void configure(CasAuthenticationFilterConfigurer filter) {
@@ -22,4 +19,12 @@ public abstract class CasSecurityConfigurerAdapter
     public void configure(CasAuthenticationProviderSecurityBuilder provider) {
     }
 
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+    }
+
+    @Override
+    @Deprecated
+    public void init(HttpSecurity http) throws Exception {
+    }
 }


### PR DESCRIPTION
- Externalize CAS `HttpSecurity` configuration inside a `CasHttpSecurityConfigurerAdapter`
- Create a static method `CasSecurityConfiguer.cas()` to retrieve a _ready to use_ `CasHttpSecurityConfigurerAdapter`
- Create new sample to show how use this `CasSecurityConfigurer.cas()`
    - And how to reuse CAS security on new `FilterChain`, for example `FilterChain` that manage `/api/**` and with different _failure entrypoint_ than no api paths

fixes #22 and fixes #18