### PR TITLE
Remove @EnableWebSecurity to don't disable default

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
@@ -56,7 +56,6 @@ import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration
 @Import({CasLoginSecurityConfiguration.class, CasAssertionUserDetailsServiceConfiguration.class,
         CasTicketValidatorConfiguration.class, DefaultCasSecurityConfigurerAdapter.class,
         DynamicCasSecurityConfiguration.class, StaticCasSecurityConfiguration.class})
-@EnableWebSecurity
 public class CasSecurityAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
If I let `@EnableWebSecurity` on _auto configuration_ class that will disable Spring boot default security and thus properties like `security.ignored` will not work anymore