### PR TITLE
Autoconfigure deps should be optional

### DIFF
--- a/cas-security-spring-boot-autoconfigure/pom.xml
+++ b/cas-security-spring-boot-autoconfigure/pom.xml
@@ -75,17 +75,20 @@
             <groupId>com.kakawait</groupId>
             <artifactId>spring-security-cas-extension</artifactId>
             <version>${spring-security-cas-extension.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <optional>true</optional>
             <scope>provided</scope>
         </dependency>
 

--- a/cas-security-spring-boot-starter/pom.xml
+++ b/cas-security-spring-boot-starter/pom.xml
@@ -44,7 +44,7 @@
 
         <spring-boot-dependencies.version>1.5.4.RELEASE</spring-boot-dependencies.version>
 
-        <cas-security-dynamic-service-resolver.version>0.3.0</cas-security-dynamic-service-resolver.version>
+        <spring-security-cas-extension.version>0.1.0</spring-security-cas-extension.version>
 
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
@@ -73,6 +73,11 @@
             <groupId>com.kakawait</groupId>
             <artifactId>cas-security-spring-boot-autoconfigure</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.kakawait</groupId>
+            <artifactId>spring-security-cas-extension</artifactId>
+            <version>${spring-security-cas-extension.version}</version>
         </dependency>
         <!-- Deprecated since 0.4.0, will be removed on 1.0.0 -->
         <dependency>


### PR DESCRIPTION
From documentation

> You should mark the dependencies to the library as optional so that you can include the autoconfigure module in your projects more easily. If you do it that way, the library won’t be provided and Spring Boot will back off by default.

http://docs.spring.io/spring-boot/docs/1.5.4.RELEASE/reference/htmlsingle/#boot-features-custom-starter-module-autoconfigure