### PR TITLE
Use null if query strings are empty

### DIFF
--- a/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/authentication/DefaultProxyCallbackAndServiceAuthenticationDetails.java
+++ b/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/authentication/DefaultProxyCallbackAndServiceAuthenticationDetails.java
@@ -2,6 +2,7 @@ package com.kakawait.spring.security.cas.web.authentication;
 
 import org.springframework.security.cas.ServiceProperties;
 import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
@@ -45,6 +46,6 @@ class DefaultProxyCallbackAndServiceAuthenticationDetails
                 .toString()
                 .replaceFirst("^\\?", "");
         return UrlUtils.buildFullRequestUrl(context.getScheme(), context.getServerName(),
-                context.getServerPort(), context.getRequestURI(), query);
+                context.getServerPort(), context.getRequestURI(), StringUtils.hasText(query) ? query : null);
     }
 }


### PR DESCRIPTION
Using `UrlUtils.buildFullRequestUrl()` if query string equals to `""` that will append `?` (but without any query string) at the end of the request.

fixes #44