### PR TITLE
Fixes 2 programmings errors

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationFilterConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasAuthenticationFilterConfigurer.java
@@ -40,7 +40,7 @@ public class CasAuthenticationFilterConfigurer {
         if (proxyAuthenticationFailureHandler != null) {
             filter.setProxyAuthenticationFailureHandler(proxyAuthenticationFailureHandler);
         }
-        if (authenticationFailureHandler != null) {
+        if (authenticationSuccessHandler != null) {
             filter.setAuthenticationSuccessHandler(authenticationSuccessHandler);
         }
         if (proxyReceptorUrl != null) {

--- a/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/authentication/CasAuthenticationSuccessHandler.java
+++ b/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/authentication/CasAuthenticationSuccessHandler.java
@@ -12,21 +12,22 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class CasAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
-    private final String ticketParameterName;
+    private final String artifactParameter;
 
-    public CasAuthenticationSuccessHandler(String ticketParameterName) {
-        Assert.notNull(ticketParameterName, "tickerParameterName must not be null!");
-        this.ticketParameterName = ticketParameterName;
+    public CasAuthenticationSuccessHandler(String artifactParameter) {
+        Assert.notNull(artifactParameter, "artifactParameter must not be null!");
+        this.artifactParameter = artifactParameter;
     }
 
     @Override
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
         String url = super.determineTargetUrl(request, response);
-        String ticket = request.getParameter(ticketParameterName);
+        String ticket = request.getParameter(artifactParameter);
         if (ticket != null) {
             url = UriComponentsBuilder
                     .fromUriString(request.getRequestURL().toString())
-                    .replaceQueryParam(ticketParameterName, new Object[0])
+                    .query(request.getQueryString())
+                    .replaceQueryParam(artifactParameter, new Object[0])
                     .build()
                     .toUriString();
         }


### PR DESCRIPTION
1. `CasAuthenticationSucessHandler` used `HttpServletRequest.getRequestURL()` that does not contains query strings!!! I have to add `HttpServletRequest.getQueryString()` before computing url
2. `CasAuthenticationFilterConfigurer` check `authenticationFailureHandler` when trying to set `authenticationSuccessHandler`