### PR TITLE
Auto add login, logout and pgt callback to matcher

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasHttpSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasHttpSecurityConfigurer.java
@@ -178,7 +178,7 @@ public class CasHttpSecurityConfigurer extends AbstractHttpConfigurer<CasHttpSec
         public void init(HttpSecurity http) throws Exception {
             CasAuthenticationFilter filter = new CasAuthenticationFilter();
             filter.setAuthenticationManager(authenticationManager());
-            filter.setRequiresAuthenticationRequestMatcher(getRequestMatcher());
+            filter.setRequiresAuthenticationRequestMatcher(getAuthenticationRequestMatcher());
             filter.setServiceProperties(serviceProperties);
             filterConfigurer.configure(filter);
 
@@ -239,7 +239,7 @@ public class CasHttpSecurityConfigurer extends AbstractHttpConfigurer<CasHttpSec
             this.authenticationManager = authenticationManager;
         }
 
-        private RequestMatcher getRequestMatcher() {
+        private RequestMatcher getAuthenticationRequestMatcher() {
             return new AntPathRequestMatcher(casSecurityProperties.getService().getPaths().getLogin());
         }
     }

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityAutoConfiguration.java
@@ -257,6 +257,11 @@ public class CasSecurityAutoConfiguration {
                     paths.add(path);
                 }
             }
+            // Add login, logout and proxy-callback paths in order to be handle by CasAuthenticationFilter.
+            // Without authentication will be broken.
+            paths.add(casSecurityProperties.getService().getPaths().getLogin());
+            paths.add(casSecurityProperties.getService().getPaths().getLogout());
+            paths.add(casSecurityProperties.getService().getPaths().getProxyCallback());
             return paths.toArray(new String[paths.size()]);
         }
     }

--- a/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java
+++ b/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java
@@ -111,7 +111,7 @@ public class CasSecuritySpringBootSampleApplication {
 
         @RequestMapping
         public String hello(Principal principal, Model model) {
-            if (StringUtils.hasText(principal.getName())) {
+            if (principal != null && StringUtils.hasText(principal.getName())) {
                 model.addAttribute("username", principal.getName());
             }
             return "index";


### PR DESCRIPTION
Since _login_, _logout_ and _proxy callback_ paths should be handle by `CasAuthenticationFilter`, they must be part on security request matching!

Without that enhancement when using `security.cas.paths` feature, if you forgot to add `/login`, `/logout` and `/cas/proxy-callback` (:arrow_left: default paths, could be different is just a sample) flow will be broken.
In addition is a bit messy to add those paths manually.

fixes #57