### PR TITLE
Rename autoconfigure package

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAssertionUserDetailsServiceConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAssertionUserDetailsServiceConfiguration.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import com.kakawait.spring.security.cas.userdetails.GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurer.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import lombok.Setter;
 import lombok.experimental.Accessors;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilder.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilder.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import com.kakawait.spring.security.cas.authentication.DynamicProxyCallbackUrlCasAuthenticationProvider;
 import lombok.Setter;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasHttpSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasHttpSecurityConfigurer.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import lombok.NonNull;
 import org.jasig.cas.client.session.SingleSignOutFilter;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfiguration.java
@@ -1,6 +1,6 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
-import com.kakawait.spring.boot.security.cas.SpringBoot1CasHttpSecurityConfigurerAdapter.SpringBoot1SecurityProperties;
+import com.kakawait.spring.boot.security.cas.autoconfigure.SpringBoot1CasHttpSecurityConfigurerAdapter.SpringBoot1SecurityProperties;
 import com.kakawait.spring.security.cas.LaxServiceProperties;
 import com.kakawait.spring.security.cas.client.ticket.AttributePrincipalProxyTicketProvider;
 import com.kakawait.spring.security.cas.client.ticket.ProxyTicketProvider;
@@ -45,11 +45,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration.CasLoginSecurityConfiguration;
-import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration.DefaultCasSecurityConfigurerAdapter;
-import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration.DynamicCasSecurityConfiguration;
-import static com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration.StaticCasSecurityConfiguration;
-import static com.kakawait.spring.boot.security.cas.CasSecurityProperties.CAS_AUTH_ORDER;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration.CasLoginSecurityConfiguration;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration.DefaultCasSecurityConfigurerAdapter;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration.DynamicCasSecurityConfiguration;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration.StaticCasSecurityConfiguration;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityProperties.CAS_AUTH_ORDER;
 
 /**
  * @author Thibaud Leprêtre

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityCondition.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityCondition.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityConfigurer.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.springframework.security.config.annotation.SecurityBuilder;
 import org.springframework.security.config.annotation.SecurityConfigurer;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityConfigurerAdapter.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityConfigurerAdapter.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityProperties.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityProperties.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import lombok.Data;
 import lombok.Getter;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurer.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import lombok.NonNull;
 import lombok.Setter;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilder.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilder.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import lombok.Setter;
 import lombok.experimental.Accessors;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorConfiguration.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.jasig.cas.client.validation.TicketValidator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/SpringBoot1CasHttpSecurityConfigurerAdapter.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/SpringBoot1CasHttpSecurityConfigurerAdapter.java
@@ -1,4 +1,4 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
@@ -12,7 +12,7 @@ import org.springframework.util.ReflectionUtils;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static com.kakawait.spring.boot.security.cas.SpringBoot1CasHttpSecurityConfigurerAdapter.SpringBoot1SecurityProperties.SECURITY_PROPERTIES_HEADERS_CLASS;
+import static com.kakawait.spring.boot.security.cas.autoconfigure.SpringBoot1CasHttpSecurityConfigurerAdapter.SpringBoot1SecurityProperties.SECURITY_PROPERTIES_HEADERS_CLASS;
 
 /**
  * @author Thibaud Leprêtre

--- a/cas-security-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/cas-security-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurerTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurerTest.java
@@ -1,6 +1,7 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasAuthenticationFilterConfigurer;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilderTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilderTest.java
@@ -1,5 +1,7 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasAuthenticationProviderSecurityBuilder;
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityProperties;
 import com.kakawait.spring.security.cas.authentication.DynamicProxyCallbackUrlCasAuthenticationProvider;
 import org.jasig.cas.client.validation.TicketValidator;
 import org.junit.Before;

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfigurationTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfigurationTest.java
@@ -1,6 +1,7 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration;
 import com.kakawait.spring.security.cas.LaxServiceProperties;
 import com.kakawait.spring.security.cas.client.ticket.AttributePrincipalProxyTicketProvider;
 import com.kakawait.spring.security.cas.client.ticket.ProxyTicketProvider;
@@ -16,7 +17,6 @@ import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -173,7 +173,7 @@ public class CasSecurityAutoConfigurationTest {
     public void autoConfigure_EmptyConfiguration_DefaultCasSecurityConfigurerAdapterBean() {
         load(EmptyConfiguration.class);
 
-        String beanName ="com.kakawait.spring.boot.security.cas.CasSecurityAutoConfiguration$" +
+        String beanName ="com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityAutoConfiguration$" +
                 "DefaultCasSecurityConfigurerAdapter";
         context.getBean(beanName);
     }

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurerTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurerTest.java
@@ -1,5 +1,6 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasSingleSignOutFilterConfigurer;
 import org.jasig.cas.client.session.SessionMappingStorage;
 import org.jasig.cas.client.session.SingleSignOutFilter;
 import org.junit.Test;

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
@@ -1,5 +1,6 @@
-package com.kakawait.spring.boot.security.cas;
+package com.kakawait.spring.boot.security.cas.autoconfigure;
 
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasTicketValidatorBuilder;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.proxy.ProxyRetriever;
 import org.jasig.cas.client.ssl.HttpURLConnectionFactory;
@@ -36,11 +37,11 @@ public class CasTicketValidatorBuilderTest {
     private static final String CAS_SERVER_URL_PREFIX = "http://my.cas.server.base.url/";
 
     private static final String V1_WARN_MESSAGE_TEMPLATE =
-            "WARN com.kakawait.spring.boot.security.cas.CasTicketValidatorBuilder - " +
+            "WARN com.kakawait.spring.boot.security.cas.autoconfigure.CasTicketValidatorBuilder - " +
                     "Configuration \"%s\" isn't possible using protocol version 1, will be omitted!";
 
     private static final String SERVICE_VALIDATOR_WARN_MESSAGE_TEMPLATE =
-            "WARN com.kakawait.spring.boot.security.cas.CasTicketValidatorBuilder - " +
+            "WARN com.kakawait.spring.boot.security.cas.autoconfigure.CasTicketValidatorBuilder - " +
                     "Configuration \"%s\" isn't possible using service ticket validator " +
                     "(please consider proxy ticket validator), will be omitted!";
 

--- a/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
+++ b/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
@@ -1,10 +1,8 @@
 package com.kakawait.sample;
 
-import com.kakawait.spring.boot.security.cas.CasHttpSecurityConfigurer;
-import com.kakawait.spring.boot.security.cas.CasSecurityCondition;
-import com.kakawait.spring.boot.security.cas.CasSecurityConfigurer;
-import com.kakawait.spring.boot.security.cas.CasSecurityConfigurerAdapter;
-import com.kakawait.spring.boot.security.cas.CasSecurityProperties;
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasHttpSecurityConfigurer;
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityCondition;
+import com.kakawait.spring.boot.security.cas.autoconfigure.CasSecurityConfigurerAdapter;
 import com.kakawait.spring.security.cas.client.CasAuthorizationInterceptor;
 import com.kakawait.spring.security.cas.client.ticket.ProxyTicketProvider;
 import com.kakawait.spring.security.cas.client.validation.AssertionProvider;
@@ -13,13 +11,11 @@ import org.jasig.cas.client.authentication.AttributePrincipalImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -49,7 +45,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import java.lang.reflect.Field;
 import java.security.Principal;


### PR DESCRIPTION
From `com.kakawait.spring.boot.security.cas` to `com.kakawait.spring.boot.security.cas.autoconfigure`

fixes #33