### PR TITLE
Add some modifications to support older cas client

### DIFF
--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasHttpSecurityConfigurer.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasHttpSecurityConfigurer.java
@@ -177,6 +177,7 @@ public class CasHttpSecurityConfigurer extends AbstractHttpConfigurer<CasHttpSec
             filterConfigurer.configure(filter);
 
             SingleSignOutFilter singleSignOutFilter = new SingleSignOutFilter();
+            singleSignOutFilter.setCasServerUrlPrefix(casSecurityProperties.getServer().getBaseUrl().toASCIIString());
             singleSignOutFilterConfigurer.configure(singleSignOutFilter);
 
             http.exceptionHandling().authenticationEntryPoint(authenticationEntryPoint)

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityProperties.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityProperties.java
@@ -32,7 +32,7 @@ public class CasSecurityProperties {
     private Service service = new Service();
 
     /**
-     * @see org.springframework.security.cas.authentication.CasAuthenticationProvider#key
+     * @see org.springframework.security.cas.authentication.CasAuthenticationProvider
      */
     private String key = UUID.randomUUID().toString();
 
@@ -132,7 +132,7 @@ public class CasSecurityProperties {
             /**
              * CAS Server login path that will be append to {@link Server#baseUrl}
              *
-             * @see org.springframework.security.cas.web.CasAuthenticationEntryPoint#loginUrl
+             * @see org.springframework.security.cas.web.CasAuthenticationEntryPoint
              */
             private String login = "/login";
 
@@ -188,7 +188,7 @@ public class CasSecurityProperties {
             /**
              * CAS Service logout path that will be append to {@link Service#baseUrl}
              *
-             * @see org.springframework.security.web.authentication.logout.LogoutFilter#logoutRequestMatcher
+             * @see org.springframework.security.web.authentication.logout.LogoutFilter
              */
             private String logout = "/logout";
 
@@ -197,7 +197,7 @@ public class CasSecurityProperties {
              * fallback to {@link Service#baseUrl}
              *
              * @see Service#callbackBaseUrl
-             * @see org.jasig.cas.client.validation.Cas20ServiceTicketValidator#proxyCallbackUrl
+             * @see org.jasig.cas.client.validation.Cas20ServiceTicketValidator
              */
             private String proxyCallback;
         }

--- a/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/RequestAwareCasAuthenticationEntryPoint.java
+++ b/spring-security-cas-extension/src/main/java/com/kakawait/spring/security/cas/web/RequestAwareCasAuthenticationEntryPoint.java
@@ -17,7 +17,8 @@ import static org.springframework.web.servlet.support.ServletUriComponentsBuilde
  */
 public class RequestAwareCasAuthenticationEntryPoint extends CasAuthenticationEntryPoint {
 
-    private final URI loginPath;
+    @SuppressWarnings("WeakerAccess")
+    protected final URI loginPath;
 
     public RequestAwareCasAuthenticationEntryPoint(URI loginPath) {
         Assert.notNull(loginPath, "login path is required, it must not be null");
@@ -37,7 +38,8 @@ public class RequestAwareCasAuthenticationEntryPoint extends CasAuthenticationEn
                 getServiceProperties().getServiceParameter(), getServiceProperties().getArtifactParameter(), true);
     }
 
-    private static Optional<String> buildUrl(HttpServletRequest request, URI path) {
+    @SuppressWarnings("WeakerAccess")
+    protected static Optional<String> buildUrl(HttpServletRequest request, URI path) {
         Assert.notNull(request, "request is required; it must not be null");
         if (!path.isAbsolute()) {
             return Optional.of(fromContextPath(request).path(path.toASCIIString()).toUriString());


### PR DESCRIPTION
On cas-client <= 3.3, if `casServerPrefix` is not defined it throws an exception
In addition on same range of version the `constructServiceUrl` API is deprected, so open some code to `protected` to allow user override behavior to use old api