### PR TITLE
Candidate for 1.1.0 with java 11 and springboot 2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0](https://github.com/kakawait/cas-security-spring-boot-starter/milestones) (miliestone number of v2.0.0 to be determined by owner) - 04 jul 2022
+
+- Apply pom code convention (https://maven.apache.org/developers/conventions/code.html#pom-code-convention)
+- Use java 11
+- Use spring-boot 2.6.9. (When 2.7.0 or higher will be used, it will become a breaking change thus the upgrade to a major version)
+
 ## [1.0.6](https://github.com/kakawait/cas-security-spring-boot-starter/milestone/28) - 26 nov 2020
 
 - Add support for CAS client >= 3.6 ([#147](https://github.com/kakawait/cas-security-spring-boot-starter/issues/147))
@@ -37,6 +43,7 @@ to extends...
 
 ### Breaking changes
 
+- Related to [#161 Use springboot 2.7.0+ with SecurityFilterChain instead of deprecated WebSecurityConfigurerAdapter](https://github.com/kakawait/cas-security-spring-boot-starter/issues/161), when we upgrade to spring-boot v2.7.0+ we will get a warning when we use the WebSecurityConfigurerAdapter class. This will have to be addressed before we upgrade.
 - Related to [#35 Remove cas-security-dynamic-service-resolver module](https://github.com/kakawait/cas-security-spring-boot-starter/issues/35), you must use [spring-security-cas-extension](https://github.com/kakawait/cas-security-spring-boot-starter/tree/master/spring-security-cas-extension) instead.
 - Related to [#33
 Rename package com.kakawait.spring.boot.security.cas to com.kakawait.spring.boot.security.cas.autoconfigure](https://github.com/kakawait/cas-security-spring-boot-starter/issues/33), you must rewrite your `import` statements to append `.autoconfigure.`.
@@ -82,3 +89,15 @@ security:
 ```
 
 Where `security.cas.authorization.roles` (which only useful when using `security.cas.authorization.mode=ROLE`) is _list_ of roles that use must have to be accepted.
+
+##### As of _Spring Boot 2.7.0_ the WebSecurityConfigurerAdapter is deprecated
+
+See [HttpSecurity](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#jc-httpsecurity)
+
+You will have to change your application SecurityConfiguration:
+* remove the _extends WebSecurityConfigurerAdapter_
+* change your _public void configure(HtppSecurity http)_ method to _public SecurityFilterChain filterChain(HttpSecurity http)_
+* Annotatate this method with _@Bean_
+* keep the content, but using LambdaDSL is preferred
+
+See [HttpSecurity](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#jc-httpsecurity)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Apply pom code convention (https://maven.apache.org/developers/conventions/code.html#pom-code-convention)
 - Use java 11
-- Use spring-boot 2.7.x (this causes a breaking change thus the upgrade to a major version)
+- Use spring-boot 2.7.1 (this causes a breaking change thus the upgrade to a major version)
 
 ## [1.0.6](https://github.com/kakawait/cas-security-spring-boot-starter/milestone/28) - 26 nov 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0](https://github.com/kakawait/cas-security-spring-boot-starter/milestones) (miliestone number of v2.0.0 to be determined by owner) - 04 jul 2022
+## [1.1.0](https://github.com/kakawait/cas-security-spring-boot-starter/milestone/22) - 06 jul 2022
 
 - Apply pom code convention (https://maven.apache.org/developers/conventions/code.html#pom-code-convention)
 - Use java 11
-- Use spring-boot 2.7.1 (this causes a breaking change thus the upgrade to a major version)
+- Use spring-boot 2.6.9
 
 ## [1.0.6](https://github.com/kakawait/cas-security-spring-boot-starter/milestone/28) - 26 nov 2020
 
@@ -43,7 +43,6 @@ to extends...
 
 ### Breaking changes
 
-- Related to [#161 Use springboot 2.7.0+ with SecurityFilterChain instead of deprecated WebSecurityConfigurerAdapter](https://github.com/kakawait/cas-security-spring-boot-starter/issues/161), when we upgrade to spring-boot v2.7.0+ we will get a warning when we use the WebSecurityConfigurerAdapter class. This will have to be addressed before we upgrade.
 - Related to [#35 Remove cas-security-dynamic-service-resolver module](https://github.com/kakawait/cas-security-spring-boot-starter/issues/35), you must use [spring-security-cas-extension](https://github.com/kakawait/cas-security-spring-boot-starter/tree/master/spring-security-cas-extension) instead.
 - Related to [#33
 Rename package com.kakawait.spring.boot.security.cas to com.kakawait.spring.boot.security.cas.autoconfigure](https://github.com/kakawait/cas-security-spring-boot-starter/issues/33), you must rewrite your `import` statements to append `.autoconfigure.`.
@@ -89,15 +88,3 @@ security:
 ```
 
 Where `security.cas.authorization.roles` (which only useful when using `security.cas.authorization.mode=ROLE`) is _list_ of roles that use must have to be accepted.
-
-##### As of _Spring Boot 2.7.0_ the WebSecurityConfigurerAdapter is deprecated
-
-See [HttpSecurity](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#jc-httpsecurity)
-
-You will have to change your application SecurityConfiguration:
-* remove the _extends WebSecurityConfigurerAdapter_
-* change your _public void configure(HtppSecurity http)_ method to _public SecurityFilterChain filterChain(HttpSecurity http)_
-* Annotatate this method with _@Bean_
-* keep the content, but using LambdaDSL is preferred
-
-See [HttpSecurity](https://docs.spring.io/spring-security/reference/servlet/configuration/java.html#jc-httpsecurity)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Apply pom code convention (https://maven.apache.org/developers/conventions/code.html#pom-code-convention)
 - Use java 11
-- Use spring-boot 2.6.9. (When 2.7.0 or higher will be used, it will become a breaking change thus the upgrade to a major version)
+- Use spring-boot 2.7.x (this causes a breaking change thus the upgrade to a major version)
 
 ## [1.0.6](https://github.com/kakawait/cas-security-spring-boot-starter/milestone/28) - 26 nov 2020
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Security CAS starter
 
 [![Travis](https://img.shields.io/travis/kakawait/cas-security-spring-boot-starter.svg)](https://travis-ci.org/kakawait/cas-security-spring-boot-starter)
-[![Maven Central](https://img.shields.io/maven-central/v/com.kakawait/cas-security-spring-boot-starter.svg)](https://search.maven.org/#artifactdetails%7Ccom.kakawait%7Ccas-security-spring-boot-starter%7C2.0.0%7Cjar)
+[![Maven Central](https://img.shields.io/maven-central/v/com.kakawait/cas-security-spring-boot-starter.svg)](https://search.maven.org/#artifactdetails%7Ccom.kakawait%7Ccas-security-spring-boot-starter%7C1.1.0%7Cjar)
 [![License](https://img.shields.io/github/license/kakawait/cas-security-spring-boot-starter.svg)](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/LICENSE.md)
 [![Codecov](https://img.shields.io/codecov/c/github/kakawait/cas-security-spring-boot-starter.svg)](https://codecov.io/gh/kakawait/cas-security-spring-boot-starter)
 [![SonarQube Tech Debt](https://img.shields.io/sonar/https/sonarcloud.io/com.kakawait%3Acas-security-spring-boot-parent/tech_debt.svg)](https://sonarcloud.io/dashboard?id=com.kakawait%3Acas-security-spring-boot-parent)
@@ -26,7 +26,7 @@ Add the Spring boot starter to your project
 <dependency>
   <groupId>com.kakawait</groupId>
   <artifactId>cas-security-spring-boot-starter</artifactId>
-  <version>2.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Security CAS starter
 
 [![Travis](https://img.shields.io/travis/kakawait/cas-security-spring-boot-starter.svg)](https://travis-ci.org/kakawait/cas-security-spring-boot-starter)
-[![Maven Central](https://img.shields.io/maven-central/v/com.kakawait/cas-security-spring-boot-starter.svg)](https://search.maven.org/#artifactdetails%7Ccom.kakawait%7Ccas-security-spring-boot-starter%7C1.0.6%7Cjar)
+[![Maven Central](https://img.shields.io/maven-central/v/com.kakawait/cas-security-spring-boot-starter.svg)](https://search.maven.org/#artifactdetails%7Ccom.kakawait%7Ccas-security-spring-boot-starter%7C2.0.0%7Cjar)
 [![License](https://img.shields.io/github/license/kakawait/cas-security-spring-boot-starter.svg)](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/LICENSE.md)
 [![Codecov](https://img.shields.io/codecov/c/github/kakawait/cas-security-spring-boot-starter.svg)](https://codecov.io/gh/kakawait/cas-security-spring-boot-starter)
 [![SonarQube Tech Debt](https://img.shields.io/sonar/https/sonarcloud.io/com.kakawait%3Acas-security-spring-boot-parent/tech_debt.svg)](https://sonarcloud.io/dashboard?id=com.kakawait%3Acas-security-spring-boot-parent)
@@ -11,11 +11,11 @@
 
 ## Features
 
-- Spring boot 1 and 2 support
+- Spring boot 1 and 2 support.
 - Configures CAS authentication and authorization
 - Support dynamic service resolution based on current `HttpServletRequest`
 - Advance configuration through [CasSecurityConfigurerAdapter](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityConfigurerAdapter.java)
-- Integration with _Basic authentication_ if `security.basic.enabled=true` that allow you to authenticate using header `Authorization: Basic ...` in addition to _CAS_
+- Integration with _Basic authentication_ if `security.basic.enabled=true` will allow you to authenticate using header `Authorization: Basic ...` in addition to _CAS_
 - `RestTemplate` integration
 
 ## Setup
@@ -26,11 +26,12 @@ Add the Spring boot starter to your project
 <dependency>
   <groupId>com.kakawait</groupId>
   <artifactId>cas-security-spring-boot-starter</artifactId>
-  <version>1.0.6</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
 But be careful `1.x.x` version has some **breaking changes** if you comes from `0.x.x` version.
+But be careful `2.x.x` version will have some **breaking changes** if you comes from `1.x.x` version.
 
 Please checkout [CHANGELOG.md](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/CHANGELOG.md), in particular `breaking changes` sections.
 
@@ -68,7 +69,7 @@ security:
 
 _dynamic_ resolution mode is a novel mode from that starter that will allow you to do not hard-code service url in your configuration. Thereby your configuration will be more portable and easy to use.
 
-**ATTENTION** _dynamic_ resolution mode use information from `HttpServletRequest` to build service url, that can be a security breach if you do not control headers like `Host` or `X-Forwarded-*` that why _dynamic_ resolution mode **is not the default mode** and you must activate it as describe on below properties.
+**ATTENTION** _dynamic_ resolution mode use information from `HttpServletRequest` to build service url, that can be a security breach if you do not control headers like `Host` or `X-Forwarded-*` that why _dynamic_ resolution mode **is not the default mode** and you must activate it as described in below properties.
 
 ```yml
 security:
@@ -104,7 +105,7 @@ The supported properties are:
 |---------------------------------------------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `security.cas.enabled`                      | `true`                         | Enable CAS security                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `security.cas.key`                          | `UUID.randomUUID().toString()` | An id used by the [`CasAuthenticationProvider`](https://docs.spring.io/spring-security/site/docs/current/apidocs/org/springframework/security/cas/authentication/CasAuthenticationProvider.html#setKey-java.lang.String-)                                                                                                                                                                                                                                                                                                                                                                             |
-| `security.cas.paths`                        | `/**`                          | Comma-separated list of paths to secure (work as same way as `security.basic.path`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `security.cas.paths`                        | `/**`                          | Comma-separated list of paths to secure (works the same way as `security.basic.path`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `security.cas.user.default-roles`           | `USER`                         | Comma-separated list of default user roles. If roles have been found from `security.cas.user.roles-attributes` default roles will be append to the list of users roles                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `security.cas.user.roles-attributes`        |                                | Comma-separated list of CAS attributes to be used to determine user roles                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `security.cas.proxy-validation.enabled`     | `true`                         | Defines if proxy should be checked again chains `security.cas.proxy-validation.chains`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -113,13 +114,13 @@ The supported properties are:
 | `security.cas.server.base-url`              |                                | The start of the CAS server url, i.e. https://localhost:8443/cas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `security.cas.server.validation-base-url`   |                                | Optional, `security.cas.server.base-url` is used if missing. The start of the CAS server url (similar to `security.cas.server.base-url`) used during ticket validation flow. Could be useful when server (your service) to server (CAS server) network is different from your external/browser network (i.e. docker environment, see [docker profile properties](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/resources/application.yml)).                                                                                       |
 | `security.cas.server.paths.login`           | `/login`                       | Defines the location of the CAS server login path that will be append to the existing `security.cas.server.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `security.cas.server.paths.logout`          | `/logout`                      | Defines the location of the CAS server logout path that will be append to the existing `security.cas.server.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `security.cas.service.resolution-mode`      | `static`                       | Resolution modes can be `static` or `dynamic`, by default is `static` and you must fill `security.cas.service.base-url` whereas in `dynamic` mode service url will be generated from receiving `HttpServletRequest`. **Attention** will not override `security.cas.server.validation-base-url` and `security.cas.service.callback-base-url` if defined, see [docker profile properties](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/resources/application.yml) to get an example.                                               |
+| `security.cas.server.paths.logout`          | `/logout`                      | Defines the location of the CAS server logout path that will be appended to the existing `security.cas.server.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `security.cas.service.resolution-mode`      | `static`                       | Resolution modes can be `static` or `dynamic`, the default is `static` and you must fill `security.cas.service.base-url` whereas in `dynamic` mode service url will be generated from receiving `HttpServletRequest`. **Attention** will not override `security.cas.server.validation-base-url` and `security.cas.service.callback-base-url` if defined, see [docker profile properties](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/resources/application.yml) to get an example.                                               |
 | `security.cas.service.base-url`             |                                | The name of the server this application is hosted on. Service URL will be dynamically constructed using this, i.e. https://localhost:8443 (you must include the protocol, but port is optional if it's a standard port). Skipped if resolution mode is `dynamic`.                                                                                                                                                                                                                                                                                                                                     |
 | `security.cas.service.callback-base-url`    |                                | Optional, `security.cas.service.base-url` is used if missing. Represents the base url that will be used to compute _Proxy granting ticket callback_ (see `security.cas.service.paths.proxy-callback`). It could be useful to be different from `security.cas.service.base-url` when server (CAS server) to server (your service) network is different from your external/browser network (i.e. docker environment, see see [docker profile properties](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/resources/application.yml)). |
-| `security.cas.service.paths.login`          | `/login`                       | Defines the application login path that will be append to the existing `security.cas.service.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `security.cas.service.paths.logout`         | `/logout`                      | Defines the application logout path that will be append to the existing `security.cas.service.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `security.cas.service.paths.proxy-callback` |                                | The callback path that will be, if present, append to the `security.cas.service.callback-base-url` or `security.cas.service.base-url` and add to as parameter inside request validation. **It must be set if you want to receive _Proxy Granting Ticket_ `PGT`**.                                                                                                                                                                                                                                                                                                                                     |
+| `security.cas.service.paths.login`          | `/login`                       | Defines the application login path that will be appended to the existing `security.cas.service.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `security.cas.service.paths.logout`         | `/logout`                      | Defines the application logout path that will be appended to the existing `security.cas.service.base-url` url                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `security.cas.service.paths.proxy-callback` |                                | The callback path that will be, if present, appended to the `security.cas.service.callback-base-url` or `security.cas.service.base-url` and added to as parameter inside request validation. **It must be set if you want to receive _Proxy Granting Ticket_ `PGT`**.                                                                                                                                                                                                                                                                                                                                     |
 
 Otherwise you can checkout [CasSecurityProperties](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/CasSecurityProperties.java) class.
 
@@ -163,7 +164,7 @@ Otherwise many beans defined in that starter are annotated with `@ConditionOnMis
 
 Starter does not provide any additional _proxy granting storage_ (yet), by default an _in memory_ storage is used [`ProxyGrantingTicketStorageImpl`](https://github.com/apereo/java-cas-client/blob/master/cas-client-core/src/main/java/org/jasig/cas/client/proxy/ProxyGrantingTicketStorageImpl.java).
 
-To override it you can expose a `ProxyGrantingTicketStorage` beans like following:
+To override it you can expose a `ProxyGrantingTicketStorage` bean like following:
 
 ```java
 @Bean
@@ -256,7 +257,7 @@ You can checkout & run sample module [`cas-security-spring-boot-sample`](https:/
 
 ## Proxy chains validation
 
-By default client configuration is `security.cas.proxy-validation.enabled = true` with empty proxy chains (`security.cas.proxy-validation.chains`). That mean you will not be able to validate proxy ticket since proxy chains is empty.
+By default client configuration is `security.cas.proxy-validation.enabled = true` with empty proxy chains (`security.cas.proxy-validation.chains`). That means you will not be able to validate proxy ticket since proxy chains is empty.
 
 You should disable proxy validation using:
 
@@ -297,7 +298,7 @@ security.cas.proxy-validation.chains[2] = ^http://my\\.domain\\..*
 
 Since `0.7.0` version, there is a simple integration with `RestTemplate` but not enabled by default.
 
-In order to enabled it you must create your own `RestTemplate` bean and adding an _interceptor_
+In order to enable it you must create your own `RestTemplate` bean and add an _interceptor_
 
 ```java
 @Bean
@@ -311,18 +312,18 @@ RestTemplate casRestTemplate(ServiceProperties serviceProperties, ProxyTicketPro
 This _interceptor_ is pretty simple, it will simply ask a new _proxy ticket_ for each request and append it to request query parameter.
 For example with: `http://httpbin.org/get` interceptor will modify request uri to become `http://httpbin.org/get?ticket=PT-XX-YYYYYYYYYY`.
 
-**ATTENTION** if _interceptor_ get any issue to get _proxy ticket_ from CAS server, it will throw an `IllegalStateException`.
+**ATTENTION** if _interceptor_ gets any issue to get _proxy ticket_ from CAS server, it will throw an `IllegalStateException`.
 
-Please checkout You can found sample usage for both on [`CasSecuritySpringBootSampleApplication`](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java) to get an sample usage.
+Please checkout You can find sample usage for both on [`CasSecuritySpringBootSampleApplication`](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java)
 
 ### AssertionProvider and ProxyTicketProvider
 
-In addition to `RestTemplate` integration, since `0.7.0` there is now two new autoconfigured beans:
+In addition to `RestTemplate` integration, since `0.7.0` there are now two new autoconfigured beans:
 
 1. `AssertionProvider` that will provide you a way to retrieve the current (bounded to current authenticated request) `org.jasig.cas.client.validation.Assertion`
 2. `ProxyTicketProvider` that will provide you a simple way to ask a _proxy ticket_ for a given service (regarding the current authenticated request)
 
-You can found sample usage for both on [`CasSecuritySpringBootSampleApplication`](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java)
+You can find sample usage for both on [`CasSecuritySpringBootSampleApplication`](https://github.com/kakawait/cas-security-spring-boot-starter/blob/master/cas-security-spring-boot-sample/src/main/java/com/kakawait/CasSecuritySpringBootSampleApplication.java)
 
 ## License
 

--- a/cas-security-spring-boot-autoconfigure/pom.xml
+++ b/cas-security-spring-boot-autoconfigure/pom.xml
@@ -4,18 +4,29 @@
                         http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cas-security-spring-boot-autoconfigure</artifactId>
-    <packaging>jar</packaging>
-
+    <!-- Do NOT change then order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
         <version>1.0.6</version>
     </parent>
 
+    <artifactId>cas-security-spring-boot-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+
     <name>Cas security spring boot autoconfigure</name>
     <description>Spring boot autoconfigure for Apereo CAS client fully integrated with Spring security</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.kakawait</groupId>
+                <artifactId>spring-security-cas-extension</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -24,7 +35,6 @@
         <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>spring-security-cas-extension</artifactId>
-            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -69,6 +79,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/cas-security-spring-boot-autoconfigure/pom.xml
+++ b/cas-security-spring-boot-autoconfigure/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>2.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>cas-security-spring-boot-autoconfigure</artifactId>

--- a/cas-security-spring-boot-autoconfigure/pom.xml
+++ b/cas-security-spring-boot-autoconfigure/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>1.0.6</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>cas-security-spring-boot-autoconfigure</artifactId>

--- a/cas-security-spring-boot-autoconfigure/pom.xml
+++ b/cas-security-spring-boot-autoconfigure/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                         http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Do NOT change then order of tags or plugins as this might affect the results of the build. -->
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
     <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <parent>
         <groupId>com.kakawait</groupId>
@@ -18,20 +18,12 @@
     <name>Cas security spring boot autoconfigure</name>
     <description>Spring boot autoconfigure for Apereo CAS client fully integrated with Spring security</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.kakawait</groupId>
-                <artifactId>spring-security-cas-extension</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>spring-security-cas-extension</artifactId>
@@ -79,9 +71,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfiguration.java
+++ b/cas-security-spring-boot-autoconfigure/src/main/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfiguration.java
@@ -72,7 +72,7 @@ public class CasSecurityAutoConfiguration {
     @ConditionalOnMissingBean(ServiceProperties.class)
     @ConditionalOnProperty(value = "security.cas.service.resolution-mode", havingValue = "static",
             matchIfMissing = true)
-    ServiceProperties serviceProperties(CasSecurityProperties casSecurityProperties) throws Exception {
+    ServiceProperties serviceProperties(CasSecurityProperties casSecurityProperties) {
         ServiceProperties serviceProperties = new ServiceProperties();
 
         URI baseUrl = casSecurityProperties.getService().getBaseUrl();
@@ -87,7 +87,7 @@ public class CasSecurityAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(ServiceProperties.class)
     @ConditionalOnProperty(value = "security.cas.service.resolution-mode", havingValue = "dynamic")
-    ServiceProperties laxServiceProperties() throws Exception {
+    ServiceProperties laxServiceProperties() {
         LaxServiceProperties serviceProperties = new LaxServiceProperties();
         serviceProperties.setAuthenticateAllArtifacts(true);
         serviceProperties.afterPropertiesSet();
@@ -323,7 +323,7 @@ public class CasSecurityAutoConfiguration {
                     paths.add(path);
                 }
             }
-            // Add login, logout and proxy-callback paths in order to be handle by CasAuthenticationFilter.
+            // Add login, logout and proxy-callback paths in order to be handled by CasAuthenticationFilter.
             // Without authentication will be broken.
             paths.add(casSecurityProperties.getService().getPaths().getLogin());
             paths.add(casSecurityProperties.getService().getPaths().getLogout());

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurerTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationFilterConfigurerTest.java
@@ -1,7 +1,7 @@
 package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetailsSource;

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilderTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasAuthenticationProviderSecurityBuilderTest.java
@@ -2,8 +2,8 @@ package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import com.kakawait.spring.security.cas.authentication.DynamicProxyCallbackUrlCasAuthenticationProvider;
 import org.jasig.cas.client.validation.TicketValidator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.context.MessageSource;
 import org.springframework.security.cas.authentication.CasAuthenticationProvider;
@@ -22,7 +22,7 @@ public class CasAuthenticationProviderSecurityBuilderTest {
 
     private CasAuthenticationProviderSecurityBuilder builder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         builder = new CasAuthenticationProviderSecurityBuilder();
     }

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfigurationTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSecurityAutoConfigurationTest.java
@@ -12,8 +12,8 @@ import com.kakawait.spring.security.cas.web.authentication.RequestAwareCasLogout
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl;
 import org.jasig.cas.client.validation.TicketValidator;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -38,6 +38,7 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Thibaud Leprêtre
@@ -52,28 +53,32 @@ public class CasSecurityAutoConfigurationTest {
 
     private ConfigurableApplicationContext context;
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (context != null) {
             context.close();
         }
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void autoConfiguration_MissingCasServerBaseUrl_SkipAutoConfiguration() {
         load(new Properties(), EmptyConfiguration.class);
 
-        context.getBean(CasSecurityAutoConfiguration.class);
+        assertThrows(NoSuchBeanDefinitionException.class,
+                () -> context.getBean(CasSecurityAutoConfiguration.class)
+        );
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void autoConfiguration_DisableProperty_SkipAutoConfiguration() {
         Properties properties = new Properties();
         properties.put("security.cas.server.base-url", CAS_SERVER_BASE_URL);
         properties.put("security.cas.enabled", "false");
         load(properties, EmptyConfiguration.class);
 
-        context.getBean(CasSecurityAutoConfiguration.class);
+        assertThrows(NoSuchBeanDefinitionException.class,
+                () -> context.getBean(CasSecurityAutoConfiguration.class)
+        );
     }
 
     @Test

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurerTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasSingleSignOutFilterConfigurerTest.java
@@ -2,7 +2,7 @@ package com.kakawait.spring.boot.security.cas.autoconfigure;
 
 import org.jasig.cas.client.session.SessionMappingStorage;
 import org.jasig.cas.client.session.SingleSignOutFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
@@ -10,13 +10,12 @@ import org.jasig.cas.client.validation.Cas30ProxyTicketValidator;
 import org.jasig.cas.client.validation.Cas30ServiceTicketValidator;
 import org.jasig.cas.client.validation.ProxyList;
 import org.jasig.cas.client.validation.TicketValidator;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,12 +24,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
 
 /**
  * @author Thibaud Leprêtre
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(OutputCaptureExtension.class)
 public class CasTicketValidatorBuilderTest {
 
     private static final String CAS_SERVER_URL_PREFIX = "http://my.cas.server.base.url/";
@@ -44,12 +42,9 @@ public class CasTicketValidatorBuilderTest {
                     "Configuration \"%s\" isn't possible using service ticket validator " +
                     "(please consider proxy ticket validator), will be omitted!";
 
-    @Rule
-    public OutputCaptureRule outputCaptureRule = new OutputCaptureRule();
-
     private CasTicketValidatorBuilder builder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         builder = new CasTicketValidatorBuilder(CAS_SERVER_URL_PREFIX);
     }
@@ -118,7 +113,7 @@ public class CasTicketValidatorBuilderTest {
     }
 
     @Test
-    public void build_ProtocolVersion1WithIncompatibleParameter_LogWarnMessage() {
+    public void build_ProtocolVersion1WithIncompatibleParameter_LogWarnMessage(CapturedOutput output) {
         int protocolVersion = 1;
 
         CasTicketValidatorBuilder builder = fulfilledBuilder();
@@ -135,12 +130,12 @@ public class CasTicketValidatorBuilderTest {
         warns.add(String.format(V1_WARN_MESSAGE_TEMPLATE, "allowEmptyProxyChain"));
 
         for (String warn : warns) {
-            outputCaptureRule.expect(containsString(warn));
+            assertThat(output).contains(warn);
         }
     }
 
     @Test
-    public void build_ServiceValidatorProtocolWithIncompatibleParameter_LogWarnMessage() {
+    public void build_ServiceValidatorProtocolWithIncompatibleParameter_LogWarnMessage(CapturedOutput output) {
         int protocolVersion = 2;
 
         CasTicketValidatorBuilder builder = fulfilledBuilder();
@@ -154,7 +149,7 @@ public class CasTicketValidatorBuilderTest {
         warns.add(String.format(SERVICE_VALIDATOR_WARN_MESSAGE_TEMPLATE, "allowEmptyProxyChain"));
 
         for (String warn : warns) {
-            outputCaptureRule.expect(containsString(warn));
+            assertThat(output).contains(warn);
         }
 
         protocolVersion = 3;
@@ -163,7 +158,7 @@ public class CasTicketValidatorBuilderTest {
         builder.build();
 
         for (String warn : warns) {
-            outputCaptureRule.expect(containsString(warn));
+            assertThat(output).contains(warn);
         }
     }
 

--- a/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
+++ b/cas-security-spring-boot-autoconfigure/src/test/java/com/kakawait/spring/boot/security/cas/autoconfigure/CasTicketValidatorBuilderTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,7 +45,7 @@ public class CasTicketValidatorBuilderTest {
                     "(please consider proxy ticket validator), will be omitted!";
 
     @Rule
-    public OutputCapture outputCapture = new OutputCapture();
+    public OutputCaptureRule outputCaptureRule = new OutputCaptureRule();
 
     private CasTicketValidatorBuilder builder;
 
@@ -135,7 +135,7 @@ public class CasTicketValidatorBuilderTest {
         warns.add(String.format(V1_WARN_MESSAGE_TEMPLATE, "allowEmptyProxyChain"));
 
         for (String warn : warns) {
-            outputCapture.expect(containsString(warn));
+            outputCaptureRule.expect(containsString(warn));
         }
     }
 
@@ -154,7 +154,7 @@ public class CasTicketValidatorBuilderTest {
         warns.add(String.format(SERVICE_VALIDATOR_WARN_MESSAGE_TEMPLATE, "allowEmptyProxyChain"));
 
         for (String warn : warns) {
-            outputCapture.expect(containsString(warn));
+            outputCaptureRule.expect(containsString(warn));
         }
 
         protocolVersion = 3;
@@ -163,7 +163,7 @@ public class CasTicketValidatorBuilderTest {
         builder.build();
 
         for (String warn : warns) {
-            outputCapture.expect(containsString(warn));
+            outputCaptureRule.expect(containsString(warn));
         }
     }
 

--- a/cas-security-spring-boot-sample/Dockerfile
+++ b/cas-security-spring-boot-sample/Dockerfile
@@ -5,6 +5,6 @@ RUN mvn clean install && mvn -f cas-security-spring-boot-sample/pom.xml clean in
 
 FROM openjdk:8-jre-alpine
 WORKDIR /app
-COPY --from=build /src/cas-security-spring-boot-sample/target/cas-security-spring-boot-sample-1.0.6.jar /app
+COPY --from=build /src/cas-security-spring-boot-sample/target/cas-security-spring-boot-sample-2.0.0.jar /app
 ENV JAVA_OPTS=""
-CMD [ "sh", "-c", "java $JAVA_OPTS -jar /app/cas-security-spring-boot-sample-1.0.6.jar" ]
+CMD [ "sh", "-c", "java $JAVA_OPTS -jar /app/cas-security-spring-boot-sample-2.0.0.jar" ]

--- a/cas-security-spring-boot-sample/Dockerfile
+++ b/cas-security-spring-boot-sample/Dockerfile
@@ -5,6 +5,6 @@ RUN mvn clean install && mvn -f cas-security-spring-boot-sample/pom.xml clean in
 
 FROM openjdk:8-jre-alpine
 WORKDIR /app
-COPY --from=build /src/cas-security-spring-boot-sample/target/cas-security-spring-boot-sample-2.0.0.jar /app
+COPY --from=build /src/cas-security-spring-boot-sample/target/cas-security-spring-boot-sample-1.1.0.jar /app
 ENV JAVA_OPTS=""
-CMD [ "sh", "-c", "java $JAVA_OPTS -jar /app/cas-security-spring-boot-sample-2.0.0.jar" ]
+CMD [ "sh", "-c", "java $JAVA_OPTS -jar /app/cas-security-spring-boot-sample-1.1.0.jar" ]

--- a/cas-security-spring-boot-sample/docker-compose.yml
+++ b/cas-security-spring-boot-sample/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: ../
       dockerfile: cas-security-spring-boot-sample/Dockerfile
-    image: cas-security-spring-boot-sample:1.0.6
+    image: cas-security-spring-boot-sample:2.0.0
     ports:
       - "8081:8081"
       - "5005"

--- a/cas-security-spring-boot-sample/docker-compose.yml
+++ b/cas-security-spring-boot-sample/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: ../
       dockerfile: cas-security-spring-boot-sample/Dockerfile
-    image: cas-security-spring-boot-sample:2.0.0
+    image: cas-security-spring-boot-sample:1.1.0
     ports:
       - "8081:8081"
       - "5005"

--- a/cas-security-spring-boot-sample/docker/pom.xml
+++ b/cas-security-spring-boot-sample/docker/pom.xml
@@ -119,7 +119,8 @@
                     <recompressZippedFiles>false</recompressZippedFiles>
                     <archive>
                         <compress>false</compress>
-                        <manifestFile>${project.build.directory}/war/work/org.apereo.cas/cas-server-webapp${app.server}/META-INF/MANIFEST.MF
+                        <manifestFile>
+                            ${project.build.directory}/war/work/org.apereo.cas/cas-server-webapp${app.server}/META-INF/MANIFEST.MF
                         </manifestFile>
                     </archive>
                     <overlays>

--- a/cas-security-spring-boot-sample/docker/pom.xml
+++ b/cas-security-spring-boot-sample/docker/pom.xml
@@ -3,10 +3,91 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd ">
     <modelVersion>4.0.0</modelVersion>
+
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <groupId>org.apereo.cas</groupId>
     <artifactId>cas-overlay</artifactId>
     <packaging>war</packaging>
     <version>1.0</version>
+
+    <properties>
+        <cas.version>5.1.3</cas.version>
+        <springboot.version>1.5.3.RELEASE</springboot.version>
+        <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
+        <app.server>-tomcat</app.server>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apereo.cas</groupId>
+                <artifactId>cas-server-webapp${app.server}</artifactId>
+                <version>${cas.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apereo.cas</groupId>
+                <artifactId>cas-server-support-json-service-registry</artifactId>
+                <version>${cas.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apereo.cas</groupId>
+                <artifactId>cas-server-support-rest</artifactId>
+                <version>${cas.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-webapp${app.server}</artifactId>
+            <type>war</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-support-json-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-support-rest</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>sonatype-releases</id>
+            <url>http://oss.sonatype.org/content/repositories/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>shibboleth-releases</id>
+            <url>https://build.shibboleth.net/nexus/content/repositories/releases</url>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>
@@ -57,68 +138,6 @@
         </plugins>
         <finalName>cas</finalName>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-webapp${app.server}</artifactId>
-            <version>${cas.version}</version>
-            <type>war</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-support-json-service-registry</artifactId>
-            <version>${cas.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apereo.cas</groupId>
-            <artifactId>cas-server-support-rest</artifactId>
-            <version>${cas.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-    </dependencies>
-
-    <properties>
-        <cas.version>5.1.3</cas.version>
-        <springboot.version>1.5.3.RELEASE</springboot.version>
-        <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
-        <app.server>-tomcat</app.server>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
-    <repositories>
-        <repository>
-            <id>sonatype-releases</id>
-            <url>http://oss.sonatype.org/content/repositories/releases/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>shibboleth-releases</id>
-            <url>https://build.shibboleth.net/nexus/content/repositories/releases</url>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <url>https://repo.spring.io/milestone</url>
-        </repository>
-    </repositories>
 
     <profiles>
         <profile>

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.9</version>
+        <version>2.7.1</version>
         <relativePath/><!-- lookup parent from repository -->
     </parent>
 

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -23,9 +23,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <jackson-databind.version>2.10.3</jackson-databind.version>
     </properties>

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -4,17 +4,20 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- Do NOT change then order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.3.RELEASE</version>
+        <relativePath/><!-- lookup parent from repository -->
+    </parent>
+
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-sample</artifactId>
     <version>1.0.6</version>
 
     <name>Cas security spring boot sample</name>
-
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
-    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Do NOT change then order of tags or plugins as this might affect the results of the build. -->
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
     <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -33,13 +33,18 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.kakawait</groupId>
+                <artifactId>cas-security-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -57,10 +62,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>cas-security-spring-boot-starter</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -72,5 +77,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -9,13 +9,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>2.6.9</version>
         <relativePath/><!-- lookup parent from repository -->
     </parent>
 
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-sample</artifactId>
-    <version>1.0.6</version>
+    <version>2.0.0</version>
 
     <name>Cas security spring boot sample</name>
 
@@ -61,6 +61,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/cas-security-spring-boot-sample/pom.xml
+++ b/cas-security-spring-boot-sample/pom.xml
@@ -9,13 +9,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.6.9</version>
         <relativePath/><!-- lookup parent from repository -->
     </parent>
 
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-sample</artifactId>
-    <version>2.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cas security spring boot sample</name>
 

--- a/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
+++ b/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
@@ -85,9 +85,9 @@ public class CasSecuritySpringBootSampleApplication {
     static class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
         /**
-         * Ignoring path by completely remove security filter on /ignored endpoint.
-         * That method should be use when you really need security/authentication.
-         * For example for resources/static endpoints
+         * Ignoring path by completely removing security filter on /ignored endpoint.
+         * That method should be used when you really need security/authentication.
+         * For example for resources/static endpoints.
          * <p>
          * If you would just like to {@code permitAll()} an endpoint you should instead check
          * {@see OverrideDefaultCasSecurity#configure} method.
@@ -103,7 +103,7 @@ public class CasSecuritySpringBootSampleApplication {
     static class OverrideDefaultCasSecurity extends CasSecurityConfigurerAdapter {
 
         /**
-         * Permit all an specific endpoint
+         * Permit all on specific endpoint.
          */
         @Override
         public void configure(HttpSecurity http) throws Exception {
@@ -126,8 +126,8 @@ public class CasSecuritySpringBootSampleApplication {
         public void configure(HttpSecurity http) throws Exception {
             // Allow GET method to /logout even if CSRF is enabled
             http.logout()
-                .logoutSuccessHandler(casLogoutSuccessHandler)
-                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"));
+                    .logoutSuccessHandler(casLogoutSuccessHandler)
+                    .logoutRequestMatcher(new AntPathRequestMatcher("/logout"));
         }
     }
 
@@ -159,11 +159,11 @@ public class CasSecuritySpringBootSampleApplication {
         @Override
         public void configure(HttpSecurity http) throws Exception {
             http.logout()
-                .permitAll()
-                // Add null logoutSuccessHandler to disable CasLogoutSuccessHandler
-                .logoutSuccessHandler(null)
-                .logoutSuccessUrl("/logout.html")
-                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"));
+                    .permitAll()
+                    // Add null logoutSuccessHandler to disable CasLogoutSuccessHandler
+                    .logoutSuccessHandler(null)
+                    .logoutSuccessUrl("/logout.html")
+                    .logoutRequestMatcher(new AntPathRequestMatcher("/logout"));
             LogoutFilter filter = new LogoutFilter(casLogoutSuccessHandler, new SecurityContextLogoutHandler());
             filter.setFilterProcessesUrl("/cas/logout");
             http.addFilterBefore(filter, LogoutFilter.class);
@@ -207,6 +207,7 @@ public class CasSecuritySpringBootSampleApplication {
          * To be able to use basic auth that could by-pass cas auth (could be useful for debug or admin).
          * You need to re-inject {@link BasicAuthenticationFilter} just before {@link CasAuthenticationFilter} after
          * building or getting the default Spring boot {@link AuthenticationManager}.
+         *
          * @param http the {@link HttpSecurity} to modify
          */
         private void enableBasicAuth(HttpSecurity http) {
@@ -228,7 +229,7 @@ public class CasSecuritySpringBootSampleApplication {
         private final AssertionProvider assertionProvider;
 
         public IndexController(RestTemplate casRestTemplate, ProxyTicketProvider proxyTicketProvider,
-                AssertionProvider assertionProvider) {
+                               AssertionProvider assertionProvider) {
             this.casRestTemplate = casRestTemplate;
             this.proxyTicketProvider = proxyTicketProvider;
             this.assertionProvider = assertionProvider;
@@ -245,8 +246,9 @@ public class CasSecuritySpringBootSampleApplication {
         }
 
         @RequestMapping("/proxy-ticket")
-        public @ResponseBody String ticket(@RequestParam(value = "service") String service,
-                Authentication authentication, Principal principal) {
+        public @ResponseBody
+        String ticket(@RequestParam(value = "service") String service,
+                      Authentication authentication, Principal principal) {
             String template = "Get proxy ticket using %s for service %s = %s";
             // Simplest (except directly using RestTemplate see method just below)
             String s1 = String.format(template, "ProxyTicketProvider", service,
@@ -263,7 +265,8 @@ public class CasSecuritySpringBootSampleApplication {
         }
 
         @RequestMapping({"/httpbin", "/rest-template"})
-        public @ResponseBody String httpbin() {
+        public @ResponseBody
+        String httpbin() {
             return casRestTemplate.getForEntity("http://httpbin.org/get", String.class).getBody();
         }
 
@@ -279,7 +282,8 @@ public class CasSecuritySpringBootSampleApplication {
 
         @Secured("ROLE_ADMIN")
         @RequestMapping(path = "/admin")
-        public @ResponseBody String roleUsingAnnotation() {
+        public @ResponseBody
+        String roleUsingAnnotation() {
             return "You're admin";
         }
 
@@ -291,7 +295,7 @@ public class CasSecuritySpringBootSampleApplication {
         }
 
         /**
-         * Hacky code please do not use that in production
+         * Hacky code please do not use that in production.
          */
         private Optional<String> getProxyGrantingTicket(Authentication authentication) {
             Optional<AttributePrincipal> attributePrincipal = getAttributePrincipal(authentication);
@@ -309,7 +313,8 @@ public class CasSecuritySpringBootSampleApplication {
     static class HelloWorldController {
 
         @RequestMapping
-        public @ResponseBody String hello(Principal principal) {
+        public @ResponseBody
+        String hello(Principal principal) {
             return principal == null ? "Hello anonymous" : "Hello " + principal.getName();
         }
     }

--- a/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
+++ b/cas-security-spring-boot-sample/src/main/java/com/kakawait/sample/CasSecuritySpringBootSampleApplication.java
@@ -136,7 +136,7 @@ public class CasSecuritySpringBootSampleApplication {
     static class ApiSecurityConfiguration extends WebSecurityConfigurerAdapter {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
-            http.antMatcher("/api/**").authorizeRequests().anyRequest().authenticated();
+            http.antMatcher("/api/**").authorizeRequests() /* TODO anyRequest().authenticated()*/;
             // Applying CAS security on current HttpSecurity (FilterChain)
             // I'm not using .apply() from HttpSecurity due to following issue
             // https://github.com/spring-projects/spring-security/issues/4422

--- a/cas-security-spring-boot-sample/src/main/resources/application.yml
+++ b/cas-security-spring-boot-sample/src/main/resources/application.yml
@@ -21,7 +21,9 @@ security:
 ---
 
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
 
 security:
   cas:

--- a/cas-security-spring-boot-sample/src/main/resources/application.yml
+++ b/cas-security-spring-boot-sample/src/main/resources/application.yml
@@ -38,5 +38,3 @@ security:
 logging:
   level:
     org.jasig.cas.client.validation: debug
-
-

--- a/cas-security-spring-boot-sample/src/test/java/com/kakawait/sample/CasSecuritySpringBootSampleApplicationIT.java
+++ b/cas-security-spring-boot-sample/src/test/java/com/kakawait/sample/CasSecuritySpringBootSampleApplicationIT.java
@@ -1,0 +1,76 @@
+package com.kakawait.sample;
+
+import com.kakawait.spring.security.cas.client.CasAuthorizationInterceptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static com.kakawait.sample.CasSecuritySpringBootSampleApplication.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+abstract class CasSecuritySpringBootSampleApplicationIT {
+
+    @Autowired
+    protected ApplicationContext applicationContext;
+
+    @Test
+    void contextLoads(ApplicationContext context) {
+        assertThat(context).isNotNull();
+    }
+
+    @Test
+    void hasForwardedHeaderFilterBeanConfigured(ApplicationContext context) {
+        FilterRegistrationBean forwardedHeaderFilter = (FilterRegistrationBean) context.getBean("forwardedHeaderFilter");
+        assertThat(forwardedHeaderFilter).isNotNull();
+
+        assertThat(forwardedHeaderFilter.getFilter()).isInstanceOf(ForwardedHeaderFilter.class);
+        assertThat(forwardedHeaderFilter.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+    }
+
+    @Test
+    void hasCasRestTemplateBeanConfigured(ApplicationContext context) {
+        RestTemplate casRestTemplate = (RestTemplate) context.getBean("casRestTemplate");
+        assertThat(casRestTemplate).isNotNull();
+
+        assertThat(casRestTemplate.getInterceptors()).hasSize(1);
+        assertThat(casRestTemplate.getInterceptors().get(0)).isInstanceOf(CasAuthorizationInterceptor.class);
+    }
+
+    @DisplayName("has static bean configured")
+    @ParameterizedTest
+    @ValueSource(classes = {SecurityConfiguration.class
+            , OverrideDefaultCasSecurity.class
+            , LogoutConfiguration.class
+            , ApiSecurityConfiguration.class
+            //, CustomLogoutConfiguration.class // In comment as custom-logout profile is NOT active
+            //, WebMvcConfiguration.class // // In comment as custom-logout profile NOT active
+            , BackwardSpringBoot1CasSecurityConfiguration.class
+            , IndexController.class
+            , HelloWorldController.class
+    })
+    void hasStaticBeanConfigured(Class clazz) {
+        var staticBean = applicationContext.getBean(clazz);
+        assertThat(staticBean).isNotNull();
+    }
+
+    @DisplayName("has noSuchBeanDefinitionException thrown")
+    @ParameterizedTest
+    @ValueSource(classes = {CustomLogoutConfiguration.class
+            , WebMvcConfiguration.class
+    })
+    void noSuchBeanDefinitionExceptionIsThrown(Class clazz) {
+        assertThatThrownBy(() -> applicationContext.getBean(clazz))
+                .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+}

--- a/cas-security-spring-boot-sample/src/test/java/com/kakawait/sample/CasSecuritySpringBootSampleApplicationWithCustomLogoutProfileIT.java
+++ b/cas-security-spring-boot-sample/src/test/java/com/kakawait/sample/CasSecuritySpringBootSampleApplicationWithCustomLogoutProfileIT.java
@@ -1,0 +1,37 @@
+package com.kakawait.sample;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.kakawait.sample.CasSecuritySpringBootSampleApplication.*;
+
+@SpringBootTest
+@ActiveProfiles("custom-logout")
+class CasSecuritySpringBootSampleApplicationWithCustomLogoutProfileIT extends CasSecuritySpringBootSampleApplicationIT {
+
+    @DisplayName("has static bean for custom-logout profile configured")
+    @ParameterizedTest
+    @ValueSource(classes = {SecurityConfiguration.class
+            , OverrideDefaultCasSecurity.class
+            //, LogoutConfiguration.class // In comment as custom-login profile is NOT active
+            , ApiSecurityConfiguration.class
+            , CustomLogoutConfiguration.class
+            , WebMvcConfiguration.class
+            , BackwardSpringBoot1CasSecurityConfiguration.class
+            , IndexController.class
+            , HelloWorldController.class
+    })
+    void hasStaticBeanConfigured(Class clazz) {
+        super.hasStaticBeanConfigured(clazz);
+    }
+
+    @DisplayName("has noSuchBeanDefinitionException thrown")
+    @ParameterizedTest
+    @ValueSource(classes = {LogoutConfiguration.class})
+    void noSuchBeanDefinitionExceptionIsThrown(Class clazz) {
+        super.noSuchBeanDefinitionExceptionIsThrown(clazz);
+    }
+}

--- a/cas-security-spring-boot-starter/pom.xml
+++ b/cas-security-spring-boot-starter/pom.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                         http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cas-security-spring-boot-starter</artifactId>
-    <packaging>jar</packaging>
-
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
         <version>1.0.6</version>
     </parent>
+
+    <artifactId>cas-security-spring-boot-starter</artifactId>
+    <packaging>jar</packaging>
 
     <name>Cas security spring boot starter</name>
     <description>Spring boot starter for Apereo CAS client fully integrated with Spring security</description>
@@ -21,17 +23,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>cas-security-spring-boot-autoconfigure</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.kakawait</groupId>
             <artifactId>spring-security-cas-extension</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
-
 </project>
-

--- a/cas-security-spring-boot-starter/pom.xml
+++ b/cas-security-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>2.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>cas-security-spring-boot-starter</artifactId>

--- a/cas-security-spring-boot-starter/pom.xml
+++ b/cas-security-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>1.0.6</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>cas-security-spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cas security spring boot parent</name>
     <description>Spring boot starter for Apereo CAS client fully integrated with Spring security</description>
@@ -68,7 +68,7 @@
         <jackson-databind.version>2.10.3</jackson-databind.version>
 
         <!-- dependencies -->
-        <spring-boot-dependencies.version>2.7.1</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.6.9</spring-boot-dependencies.version>
 
         <!-- provided dependencies -->
         <lombok.version>1.18.12</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jackson-databind.version>2.10.3</jackson-databind.version>
 
         <!-- dependencies -->
-        <spring-boot-dependencies.version>2.6.9</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.1</spring-boot-dependencies.version>
 
         <!-- provided dependencies -->
         <lombok.version>1.18.12</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-parent</artifactId>
     <packaging>pom</packaging>
@@ -12,7 +14,6 @@
     <name>Cas security spring boot parent</name>
     <description>Spring boot starter for Apereo CAS client fully integrated with Spring security</description>
     <url>https://github.com/kakawait/cas-security-spring-boot-starter</url>
-
     <licenses>
         <license>
             <name>MIT License</name>
@@ -28,17 +29,31 @@
         </developer>
     </developers>
 
-    <scm>
-        <url>https://github.com/kakawait/cas-security-spring-boot-starter</url>
-        <connection>scm:git:git@github.com:kakawait/cas-security-spring-boot-starter.git</connection>
-        <developerConnection>scm:git:git@github.com:kakawait/cas-security-spring-boot-starter.git</developerConnection>
-    </scm>
-
     <modules>
         <module>spring-security-cas-extension</module>
         <module>cas-security-spring-boot-starter</module>
         <module>cas-security-spring-boot-autoconfigure</module>
     </modules>
+
+    <scm>
+        <url>https://github.com/kakawait/cas-security-spring-boot-starter</url>
+        <connection>scm:git:git@github.com:kakawait/cas-security-spring-boot-starter.git</connection>
+        <developerConnection>scm:git:git@github.com:kakawait/cas-security-spring-boot-starter.git</developerConnection>
+    </scm>
+    <distributionManagement>
+        <repository>
+            <id>oss.sonatype.org</id>
+            <name>Sonatype OSS Staging</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <layout>default</layout>
+        </repository>
+        <snapshotRepository>
+            <id>oss.sonatype.org</id>
+            <name>Sonatype OSS Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <layout>default</layout>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -81,6 +96,18 @@
             </dependency>
 
             <dependency>
+                <groupId>com.kakawait</groupId>
+                <artifactId>cas-security-spring-boot-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.kakawait</groupId>
+                <artifactId>spring-security-cas-extension</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
@@ -89,20 +116,16 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
-                <optional>true</optional>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj-core.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito-core.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -195,20 +218,4 @@
             </build>
         </profile>
     </profiles>
-
-    <distributionManagement>
-        <repository>
-            <id>oss.sonatype.org</id>
-            <name>Sonatype OSS Staging</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-            <layout>default</layout>
-        </repository>
-        <snapshotRepository>
-            <id>oss.sonatype.org</id>
-            <name>Sonatype OSS Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <layout>default</layout>
-        </snapshotRepository>
-    </distributionManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <!-- spring managed version -->
         <jackson.version>2.10.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.kakawait</groupId>
     <artifactId>cas-security-spring-boot-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.6</version>
+    <version>2.0.0</version>
 
     <name>Cas security spring boot parent</name>
     <description>Spring boot starter for Apereo CAS client fully integrated with Spring security</description>
@@ -68,7 +68,7 @@
         <jackson-databind.version>2.10.3</jackson-databind.version>
 
         <!-- dependencies -->
-        <spring-boot-dependencies.version>2.2.5.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.6.9</spring-boot-dependencies.version>
 
         <!-- provided dependencies -->
         <lombok.version>1.18.12</lombok.version>

--- a/spring-security-cas-extension/pom.xml
+++ b/spring-security-cas-extension/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>1.0.6</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>spring-security-cas-extension</artifactId>

--- a/spring-security-cas-extension/pom.xml
+++ b/spring-security-cas-extension/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
-        <version>2.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-security-cas-extension</artifactId>

--- a/spring-security-cas-extension/pom.xml
+++ b/spring-security-cas-extension/pom.xml
@@ -4,14 +4,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spring-security-cas-extension</artifactId>
-    <packaging>jar</packaging>
-
+    <!-- Do NOT change the order of tags or plugins as this might affect the results of the build. -->
+    <!-- See https://maven.apache.org/developers/conventions/code.html#pom-code-convention -->
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>cas-security-spring-boot-parent</artifactId>
         <version>1.0.6</version>
     </parent>
+
+    <artifactId>spring-security-cas-extension</artifactId>
+    <packaging>jar</packaging>
 
     <name>Spring security cas extension</name>
     <description>Spring security cas extension and additional implementation used by the starter</description>
@@ -21,6 +23,20 @@
         <jsr305.version>3.0.2</jsr305.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax.servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${jsr305.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -37,12 +53,10 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>${javax.servlet-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>${jsr305.version}</version>
         </dependency>
 
         <dependency>
@@ -76,5 +90,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/LaxServicePropertiesTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/LaxServicePropertiesTest.java
@@ -1,11 +1,12 @@
 package com.kakawait.spring.security.cas;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.cas.ServiceProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Thibaud Leprêtre
@@ -13,21 +14,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class LaxServicePropertiesTest {
 
     @Test
-    public void afterPropertiesSet_WithDynamicServiceResolutionAndNullOrEmptyService_Ok() throws Exception {
+    public void afterPropertiesSet_WithDynamicServiceResolutionAndNullOrEmptyService_Ok() {
         LaxServiceProperties serviceProperties = new LaxServiceProperties(true);
         serviceProperties.afterPropertiesSet();
         assertThat(serviceProperties.isDynamicServiceResolution()).isTrue();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void afterPropertiesSet_WithoutDynamicServiceResolutionValueAndNullOrEmptyService_IllegalArgumentException()
-            throws Exception {
+    @Test
+    public void afterPropertiesSet_WithoutDynamicServiceResolutionValueAndNullOrEmptyService_IllegalArgumentException() {
         LaxServiceProperties serviceProperties = new LaxServiceProperties(false);
-        serviceProperties.afterPropertiesSet();
+        assertThrows(IllegalArgumentException.class, serviceProperties::afterPropertiesSet);
     }
 
     @Test
-    public void afterPropertiesSet_WithNullService_NoException() throws Exception {
+    public void afterPropertiesSet_WithNullService_NoException() {
         ServiceProperties serviceProperties = new LaxServiceProperties();
         serviceProperties.setService(null);
         serviceProperties.afterPropertiesSet();

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/authentication/DynamicProxyCallbackUrlCasAuthenticationProviderTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/authentication/DynamicProxyCallbackUrlCasAuthenticationProviderTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,7 +43,7 @@ public class DynamicProxyCallbackUrlCasAuthenticationProviderTest {
         authenticationProvider.authenticate(authentication);
 
         verify(authentication, times(1)).getDetails();
-        verifyZeroInteractions(ticketValidator);
+        verifyNoInteractions(ticketValidator);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class DynamicProxyCallbackUrlCasAuthenticationProviderTest {
         authenticationProvider.authenticate(authentication);
 
         verify(authentication, times(1)).getDetails();
-        verifyZeroInteractions(ticketValidator);
+        verifyNoInteractions(ticketValidator);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class DynamicProxyCallbackUrlCasAuthenticationProviderTest {
         authenticationProvider.authenticate(authentication);
 
         verify(authentication, times(1)).getDetails();
-        verifyZeroInteractions(ticketValidator);
+        verifyNoInteractions(ticketValidator);
     }
 
     @Test

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/authentication/DynamicProxyCallbackUrlCasAuthenticationProviderTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/authentication/DynamicProxyCallbackUrlCasAuthenticationProviderTest.java
@@ -3,10 +3,10 @@ package com.kakawait.spring.security.cas.authentication;
 import com.kakawait.spring.security.cas.web.authentication.ProxyCallbackAndServiceAuthenticationDetails;
 import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
 import org.jasig.cas.client.validation.TicketValidator;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;
 import org.springframework.security.core.Authentication;
 
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Thibaud Leprêtre
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DynamicProxyCallbackUrlCasAuthenticationProviderTest {
 
     @Mock

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/CasAuthorizationInterceptorTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/CasAuthorizationInterceptorTest.java
@@ -1,13 +1,13 @@
 package com.kakawait.spring.security.cas.client;
 
 import com.kakawait.spring.security.cas.client.ticket.ProxyTicketProvider;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequest;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Thibaud Leprêtre
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CasAuthorizationInterceptorTest {
 
     @Mock
@@ -43,7 +43,7 @@ public class CasAuthorizationInterceptorTest {
     @Captor
     private ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ServiceProperties serviceProperties = new ServiceProperties();
         serviceProperties.setService("http://localhost:8080/");

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/ticket/AttributePrincipalProxyTicketProviderTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/ticket/AttributePrincipalProxyTicketProviderTest.java
@@ -3,11 +3,11 @@ package com.kakawait.spring.security.cas.client.ticket;
 import com.kakawait.spring.security.cas.client.validation.AssertionProvider;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Thibaud Leprêtre
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AttributePrincipalProxyTicketProviderTest {
 
     @Mock
@@ -27,7 +27,7 @@ public class AttributePrincipalProxyTicketProviderTest {
 
     private ProxyTicketProvider proxyTicketProvider;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         proxyTicketProvider = new AttributePrincipalProxyTicketProvider(assertionProvider);
     }

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/validation/SecurityContextHolderAssertionProviderTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/client/validation/SecurityContextHolderAssertionProviderTest.java
@@ -1,7 +1,7 @@
 package com.kakawait.spring.security.cas.client.validation;
 
 import org.jasig.cas.client.validation.AssertionImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.cas.authentication.CasAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -14,28 +14,28 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Thibaud Leprêtre
  */
 public class SecurityContextHolderAssertionProviderTest {
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getAssertion_NullAuthentication_IllegalStateException() {
         SecurityContextHolder.getContext().setAuthentication(null);
 
         AssertionProvider provider = new SecurityContextHolderAssertionProvider();
-        provider.getAssertion();
+        assertThrows(IllegalStateException.class, provider::getAssertion);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getAssertion_UnwantedAuthenticationType_IllegalStateException() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("casuser", "Mellon");
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         AssertionProvider provider = new SecurityContextHolderAssertionProvider();
-        provider.getAssertion();
+        assertThrows(IllegalStateException.class, provider::getAssertion);
     }
 
     @Test
@@ -52,4 +52,5 @@ public class SecurityContextHolderAssertionProviderTest {
         assertThat(provider.getAssertion()).isNotNull();
         assertThat(provider.getAssertion().getPrincipal().getName()).isEqualTo(user);
     }
+
 }

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/userdetails/GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsServiceTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/userdetails/GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsServiceTest.java
@@ -2,10 +2,10 @@ package com.kakawait.spring.security.cas.userdetails;
 
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Thibaud Leprêtre
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsServiceTest {
 
     private static final Collection<? extends GrantedAuthority> DEFAULT_ROLES = Collections.unmodifiableCollection(
@@ -50,7 +50,7 @@ public class GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetail
     public void loadUserDetails_NullOrBlankPrincipalName_UsernameNotFoundException() {
         // JDK10 var needed :)
         GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService userDetailsService =
-                new GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService(new String[] {"role"},
+                new GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService(new String[]{"role"},
                         DEFAULT_ROLES);
 
         when(assertion.getPrincipal()).thenReturn(principal);
@@ -100,7 +100,7 @@ public class GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetail
         // JDK10 var needed :)
         GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService userDetailsService =
                 new GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService(
-                        new String[] {"doesNotExists"}, DEFAULT_ROLES);
+                        new String[]{"doesNotExists"}, DEFAULT_ROLES);
 
         when(assertion.getPrincipal()).thenReturn(principal);
         when(principal.getName()).thenReturn("JohnWick");
@@ -120,7 +120,7 @@ public class GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetail
         // JDK10 var needed :)
         GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService userDetailsService =
                 new GrantedAuthoritiesFromAssertionAttributesWithDefaultRolesUserDetailsService(
-                        new String[] {"role", "group"}, DEFAULT_ROLES);
+                        new String[]{"role", "group"}, DEFAULT_ROLES);
 
         when(assertion.getPrincipal()).thenReturn(principal);
         when(principal.getName()).thenReturn("JohnWick");

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/RequestAwareCasAuthenticationEntryPointTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/RequestAwareCasAuthenticationEntryPointTest.java
@@ -1,7 +1,7 @@
 package com.kakawait.spring.security.cas.web;
 
 import com.kakawait.spring.security.cas.LaxServiceProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/CasLogoutSuccessHandlerTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/CasLogoutSuccessHandlerTest.java
@@ -1,8 +1,8 @@
 package com.kakawait.spring.security.cas.web.authentication;
 
 import com.kakawait.spring.security.cas.LaxServiceProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.cas.ServiceProperties;
@@ -29,7 +29,7 @@ public class CasLogoutSuccessHandlerTest {
 
     private MockHttpServletResponse response;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/DefaultProxyCallbackAndServiceAuthenticationDetailsTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/DefaultProxyCallbackAndServiceAuthenticationDetailsTest.java
@@ -1,8 +1,8 @@
 package com.kakawait.spring.security.cas.web.authentication;
 
 import com.kakawait.spring.security.cas.LaxServiceProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.cas.ServiceProperties;
 
@@ -19,7 +19,7 @@ public class DefaultProxyCallbackAndServiceAuthenticationDetailsTest {
 
     private MockHttpServletRequest request;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         serviceProperties = new LaxServiceProperties();
         request = new MockHttpServletRequest();

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/ProxyCallbackAndServiceAuthenticationDetailsSourceTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/ProxyCallbackAndServiceAuthenticationDetailsSourceTest.java
@@ -1,7 +1,7 @@
 package com.kakawait.spring.security.cas.web.authentication;
 
 import com.kakawait.spring.security.cas.LaxServiceProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.cas.ServiceProperties;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;

--- a/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/RequestAwareCasLogoutSuccessHandlerTest.java
+++ b/spring-security-cas-extension/src/test/java/com/kakawait/spring/security/cas/web/authentication/RequestAwareCasLogoutSuccessHandlerTest.java
@@ -1,8 +1,8 @@
 package com.kakawait.spring.security.cas.web.authentication;
 
 import com.kakawait.spring.security.cas.LaxServiceProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -26,7 +26,7 @@ public class RequestAwareCasLogoutSuccessHandlerTest {
 
     private MockHttpServletResponse response;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();


### PR DESCRIPTION
I propose this set of changes as to :

* fix use of some deprecated classes in tests
* fix pom ordering, parent pom and dependencyManagement
* upgrade to java 11
* upgrade to spring-boot 2.6.9
* add integration tests for sample application
* fix property in application.yml that will disappear in the future